### PR TITLE
Husky 커밋 컨벤션 수정

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,44 +5,54 @@ module.exports = {
       2,
       "always",
       [
-        "feat",
-        "fix",
-        "docs",
-        "style",
-        "refactor",
-        "test",
-        "chore",
-        "design",
-        "comment",
-        "rename",
-        "remove",
+        "Feat",
+        "Fix",
+        "Docs",
+        "Style",
+        "Refactor",
+        "Test",
+        "Chore",
+        "Design",
+        "Comment",
+        "Rename",
+        "Remove",
       ],
     ],
-    "type-case": [2, "always", "lower-case"],
-    "subject-empty": [2, "never"], // subject가 비어 있을 수 없음
-    "type-empty": [2, "never"], // type이 비어 있을 수 없음
-    "subject-full-stop": [2, "never", "."], // 서브젝트 끝에 점을 사용하지 않음
-    "header-case": [2, "always", "lower-case"], // header를 소문자로 설정
+    "type-case": [2, "always", "pascal-case"],
+    "type-empty": [2, "never"], // type 필수 작성
+    "subject-empty": [2, "never"], // subject 필수 작성
+    "subject-case": [2, "always", "sentence-case"], // subject 첫 글자는 대문자
+    "subject-full-stop": [2, "never", "."], // 서브젝트 끝에 마침표를 사용하지 않음
   },
   plugins: [
     {
       rules: {
         "header-match-team-format": ({ header }) => {
-          const hasNoSpaceAroundColon = /^[a-z]+:.+/.test(header);
-          const valid = hasNoSpaceAroundColon;
+          const match = /^[A-Z][a-zA-Z]*: .+/.test(header);
           return [
             valid,
-            `❌ 커밋 메시지는 다음 형식을 따라야 합니다:
-  
-  타입:설명
-  
-  - 콜론(:) 앞뒤에 공백이 없어야 합니다.
-  
-  ✅ 예시:
-  feat:변경 애용 설명`,
+            `❌ 커밋 메시지는 "타입: 설명" 형식을 따라야 합니다:
+            ✅ 예시:
+              Feat: Example feature`,
           ];
         },
       },
+      "body-bullet-format": ({ body }) => {
+          if (!body || body.trim() === "") return [true];
+
+          const lines = body.trim().split("\n");
+          const invalidLines = lines.filter(
+            (line) => line.trim() !== "" && !/^-\s.+/.test(line.trim())
+          );
+
+          const isValid = invalidLines.length === 0;
+          return [
+            isValid,
+            `❌ 본문 각 줄은 "- "로 시작해야 합니다.
+            ✅ 예시:
+              - body example`,
+          ];
+        },
     },
   ],
 };


### PR DESCRIPTION
## 관련 이슈
- #14 
## PR 내용
- **이슈 타입 변경**: `lower-case` -> `pascal-case`
- **타입과 제목 사이 공백 삽입 방식 변경**: `[타입 : 제목]` → `[타입: 제목]`
- **body 관련 내용 추가** : 본문은 `-`로 시작하며, 글머리 기호 뒤에 공백을 포함
(본문 유무는 강제하지 않음)
