### PR TITLE
Feat: Add useDeepCompareEffect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sofa",
       "version": "0.1.0",
       "dependencies": {
+        "lodash.isequal": "^4.5.0",
         "next": "15.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -17,6 +18,7 @@
         "@commitlint/config-conventional": "^19.8.0",
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/lodash.isequal": "^4.5.8",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1622,6 +1624,21 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
+      "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.17.30",
@@ -5031,6 +5048,12 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "lodash.isequal": "^4.5.0",
     "next": "15.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
@@ -19,6 +20,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/lodash.isequal": "^4.5.8",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/hooks/useDeepCompareEffect.ts
+++ b/src/hooks/useDeepCompareEffect.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from "react";
+import isEqual from "lodash.isequal"; // npm install --save-dev @types/lodash.isequal
+
+export const useDeepCompareEffect = (effect: () => void, deps: unknown[]) => {
+  const previousDepsRef = useRef<unknown[]>([]);
+
+  if (!isEqual(previousDepsRef.current, deps)) {
+    previousDepsRef.current = deps;
+  }
+
+  useEffect(effect, [previousDepsRef.current]);
+};


### PR DESCRIPTION
## 관련 이슈
- close #27 

## PR 설명
의존성 배열의 deep compare를 통해 useEffect를 실행할 지 결정

**제공 값 및 함수**
| 이름 | 타입 | 설명 |
|---|---|---|
| `-` | `void` | 비교 후 effect 실행 |

**사용 예시**
prop으로 받은 `options` 객체가 구조적으로 바뀌었을 경우 useEffect(`console.log()`) 실행
```
import { useDeepCompareEffect } from '@/hooks/useDeepCompareEffect';

function Example({ options }: { options: Record<string, any> }) {
  useDeepCompareEffect(() => {
    console.log('Options deeply changed');
  }, [options]);

  return <div>Example</div>;
}

``` 
