### PR TITLE
Feat: Add useOnClickOutSide hook

### DIFF
--- a/src/hooks/useOnClickOutSide.ts
+++ b/src/hooks/useOnClickOutSide.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+export function useOnClickOutSide(
+  ref: React.RefObject<HTMLElement>,
+  handler: (event: MouseEvent | TouchEvent) => void
+) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) return;
+      handler(event);
+    };
+
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [ref, handler]);
+}


### PR DESCRIPTION
## 관련 이슈
- close #28 

## PR 설명
지정한 요소의 외부를 클릭했을 때 콜백을 실행

**제공 값 및 함수**
| 이름 | 타입 | 설명 |
|---|---|---|
| `-` | `(ref, handler)` | 외부 클릭 시 handler 호출 |

**사용 예시**
`ref`(`div` 요소를 가리키는 참조)의 외부를 클릭하면 `console.log()` 실행
```
import { useRef } from 'react';
import { useOnClickOutside } from '@/hooks/useOnClickOutside';

function Example() {
  const ref = useRef(null);

  useOnClickOutside(ref, () => {
    console.log('Clicked outside');
  });

  return <div ref={ref}>Click inside this box</div>;
}

```