### PR TITLE
Tag 및 TagList 컴포넌트 구현

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Tag from './Tag';
+
+const meta = {
+  title: 'Components/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    onDelete: { action: 'clicked delete' },
+  },
+} satisfies Meta<typeof Tag>;
+
+export default meta;
+type Story = StoryObj<typeof Tag>;
+
+export const Default: Story = {
+  args: {
+    label: 'Sample',
+  },
+};

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+
+import IconButton from '../IconButton/IconButton';
+
+interface TagProps {
+  label: string;
+  onDelete?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+export default function Tag({ label, onDelete }: TagProps) {
+  return (
+    <div className="inline-flex cursor-default items-center justify-center gap-1 rounded-md bg-gray-300 px-2 py-1 text-xs font-medium text-gray-900">
+      <span>{label}</span>
+      {onDelete && (
+        <IconButton
+          icon="IC_Close"
+          variant="ghost"
+          size="sm"
+          ariaLabel={label || `${label} 태그 삭제`}
+          onClick={onDelete}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Tag/TagList.stories.tsx
+++ b/src/components/Tag/TagList.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import TagList from './TagList';
+
+const meta = {
+  title: 'Components/TagList',
+  component: TagList,
+  tags: ['autodocs'],
+  argTypes: {
+    onDeleteTag: { action: 'delete tag clicked' },
+  },
+} satisfies Meta<typeof TagList>;
+
+export default meta;
+type Story = StoryObj<typeof TagList>;
+
+export const Default: Story = {
+  args: {
+    tags: ['React', 'TypeScript', 'Next.js'],
+  },
+  render: args => <TagList {...args} />,
+};
+
+function InteractiveDeleteTagList() {
+  const [tags, setTags] = React.useState(['React', 'Vue', 'Angular']);
+  const handleDelete = (tag: string) => {
+    setTags(prev => prev.filter(t => t !== tag));
+  };
+
+  return <TagList tags={tags} onDeleteTag={handleDelete} />;
+}
+
+// 버튼 클릭으로 태그 삭제를 보여줌
+export const InteractiveDelete: Story = {
+  render: () => <InteractiveDeleteTagList />,
+};

--- a/src/components/Tag/TagList.tsx
+++ b/src/components/Tag/TagList.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+
+import Tag from './Tag';
+
+interface TagListProps extends React.HTMLAttributes<HTMLUListElement> {
+  tags: string[];
+  onDeleteTag: (tag: string) => void;
+}
+
+const TagList = React.forwardRef<HTMLUListElement, TagListProps>(function TagList(
+  { tags, onDeleteTag },
+  ref
+) {
+  return (
+    <ul ref={ref} role="list" className="flex flex-wrap gap-2 rounded-md bg-gray-700 p-2">
+      {tags.map(tag => (
+        <li key={tag}>
+          <Tag label={tag} onDelete={() => onDeleteTag(tag)} />
+        </li>
+      ))}
+    </ul>
+  );
+});
+
+export default TagList;

--- a/src/components/Tag/TagManager.tsx
+++ b/src/components/Tag/TagManager.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+
+import TagList from './TagList';
+
+const TagManager = () => {
+  const [tags, setTags] = React.useState<string[]>(['html', 'css', '개발']); // 예시 리스트
+
+  // useCallback으로 메모이제이션을 하여 불필요한 재렌더 줄임
+  const handleDeleteTag = React.useCallback((deleteTag: string) => {
+    setTags(prev => prev.filter(tag => tag !== deleteTag));
+  }, []);
+
+  return <TagList tags={tags} onDeleteTag={handleDeleteTag} />;
+};
+
+export default TagManager;


### PR DESCRIPTION
## 관련 이슈

- close #71
- close #72 

## PR 설명
#### ✅`Tag.tsx`
- 하나의 태그 렌더링
- x 버튼 클릭 시 삭제 함수 콜백 호출 (현재 기본 이미지로 대체되어있음)

props | values | description
-- | -- | --
`children` | `React.ReactNode` | 태그에 들어갈 텍스트를 받음
`onDelete` | `() => void` | 태그 삭제 버튼 클릭 시 호출될 함수
---

#### ✅`TagList.tsx`
- 여러 개의 Tag를 나열
- 각 태그를 삭제할 수 있도록 onDelete를 Tag에 전달

props | values | description
-- | -- | --
`tags` | `string[]` | 태그 리스트
`onDeleteTag` | `(tag: string) => void` | 특정 태그를 삭제하는 상위 콜백 함수

---

#### ✅`TagManager.tsx`
- 태그의 실제 상태를 관리
- onDeleteTag 함수 정의(실제 삭제 동작이 일어남) → TagList에 넘김
- `React.useCallback`으로 메모이제이션을 통해 불필요한 재렌더 줄임

## 실행 방법

1. `page.tsx` 파일에서 `TagManager를 import
2. `return()` 함수 내에서 <TagManager/>` 컴포넌트 사용
<img width="953" height="703" alt="image" src="https://github.com/user-attachments/assets/4e134bf5-2a72-4cd7-82d8-082b28c1c3b6" />


1. `npm run dev`로 실행 및 `npm run storybook`으로 스토리 실행

https://github.com/user-attachments/assets/b753a256-e8b8-4566-9c03-8a31969336f0

