### PR TITLE
TextArea 컴포넌트 구현

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,64 @@
+// TextArea.stories.tsx
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React, { useState } from 'react';
+
+import TextArea, { TextAreaProps } from './TextArea';
+
+const meta = {
+  title: 'Components/TextArea',
+  component: TextArea,
+  tags: ['autodocs'],
+  parameters: {
+    actions: { argTypesRegex: '^on.*' },
+  },
+  argTypes: {
+    placeholder: { control: 'text' },
+    width: {
+      control: { type: 'radio' },
+      options: ['sm', 'md', 'lg'],
+    },
+    height: {
+      control: { type: 'radio' },
+      options: ['sm', 'md', 'lg'],
+    },
+    maxLength: {
+      control: 'number',
+      description: '최대 글자 수 지정',
+    },
+    radius: {
+      control: { type: 'inline-radio' },
+      options: ['none', 'sm', 'md', 'lg'],
+    },
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['default', 'surface'],
+    },
+  },
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+function InteractiveTextArea(props: TextAreaProps) {
+  const [text, setText] = useState('');
+
+  return (
+    <TextArea
+      {...props}
+      value={text}
+      onChange={e => setText(e.target.value)}
+      onSubmit={props.onSubmit ?? fn()} // fn() 사용
+    />
+  );
+}
+
+export const Default: Story = {
+  render: args => <InteractiveTextArea {...args} />,
+  args: {
+    placeholder: '무엇이든 물어보세요',
+    width: 'md',
+    height: 'md',
+    maxLength: 200,
+  },
+};

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import clsx from 'clsx';
+import React from 'react';
+import { tv } from 'tailwind-variants';
+
+const styles = tv({
+  base: 'resize-none border p-2 text-gray-900 placeholder:text-gray-300 focus:ring-1 focus:outline-none',
+  variants: {
+    variant: {
+      default: 'border-gray-300 bg-white focus:ring-gray-500',
+      surface: 'border-gray-200 bg-gray-50 focus:ring-gray-400',
+    },
+    radius: {
+      none: 'rounded-none',
+      sm: 'rounded-sm',
+      md: 'rounded',
+      lg: 'rounded-lg',
+    },
+  },
+});
+export interface TextAreaProps
+  extends Omit<
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    'value' | 'onChange' | 'onSubmit'
+  > {
+  className?: string;
+  maxLength?: number;
+  placeholder?: string;
+  value: string;
+  variant?: 'default' | 'surface';
+  width?: 'sm' | 'md' | 'lg'; // 임의로 지정한 키워드로, 추후 변경 가능성 큼
+  height?: 'sm' | 'md' | 'lg';
+  radius?: 'none' | 'sm' | 'md' | 'lg';
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onSubmit?: (e?: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}
+
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function TextArea(
+  {
+    className,
+    maxLength = 200,
+    placeholder = '무엇이든 물어보세요',
+    value,
+    variant = 'default',
+    width = 'md',
+    height = 'md',
+    radius = 'md',
+    onChange,
+    onSubmit,
+    ...rest
+  },
+  ref
+) {
+  const isOverMaxLength = value.length >= maxLength;
+
+  const widthSizes = { sm: 150, md: 250, lg: 300 };
+  const heightSizes = { sm: 80, md: 140, lg: 200 };
+
+  const classes = styles({
+    variant,
+    radius,
+  });
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // IME(한글 등) 조합 중 Enter 잘못 제출되는 것 방지
+    const isComposing =
+      (e.nativeEvent as KeyboardEvent).isComposing ||
+      (e as unknown as { isComposing?: boolean }).isComposing;
+    if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
+      e.preventDefault(); // 줄바꿈 방지
+      onSubmit?.();
+    }
+  };
+
+  return (
+    <div className="relative inline-block pb-4">
+      <textarea
+        ref={ref}
+        className={clsx(classes, className)}
+        value={value}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        maxLength={maxLength}
+        style={{ width: `${widthSizes[width]}px`, height: `${heightSizes[height]}px` }}
+        onChange={onChange}
+        onKeyDown={handleKeyDown}
+        {...rest}
+      />
+      <div
+        className={clsx(
+          'absolute right-2 -bottom-1 text-xs select-none',
+          isOverMaxLength ? 'text-red-400' : 'text-gray-500'
+        )}
+        aria-live="polite"
+        aria-atomic="true"
+        role="status"
+      >
+        {value.length}/{maxLength}
+      </div>
+    </div>
+  );
+});
+
+export default TextArea;


### PR DESCRIPTION
## 관련 이슈

- close #70 

## PR 설명
#### ✅`TextArea.tsx`
- 텍스트 입력받는 area를 렌더링
- 글자수 제한 기능
- enter로는 `onSubmit` 트리거, shift + enter로 줄넘김 구현

props | values | description
-- | -- | --
`value` | `string` | 입력 값
`onChange` | (e: React.ChangeEvent<HTMLTextAreaElement>) => void | 입력 변경 핸들러
`onSubmit` | `() => void` | Enter 입력 시 호출될 콜백 함수 (선택적)
`placeholder` | `string` | 입력창에 표시될 플레이스홀더 (기본: 안내 문구)
`width` | `number` | 텍스트 영역의 너비 (px 단위)
`height` | `number` | 텍스트 영역의 높이 (px 단위)
`maxLength` | `number` | 입력 가능한 최대 글자 수
`radius` | `string` | 모서리 각도 지정
`variant` | `string` | UI 디자인 종류 지정

---

#### ✅`TextArea.css`
- TextArea에서 사용할 `custom-scroll`을 정의

## 실행 방법
1. `page.tsx`에서 `TextArea`, `useState import
2. 입력값 변경 사항 확인을 위해 `useState`로 `text`와 `setText` 선언
3. `return()` 함수 내에서 TextArea 컴포넌트 사용
4. `npm run dev` 및 `npm run storybook`으로 실행

```
// 컴포넌트 사용 예시
<TextArea
  value={text}
  onChange={(e) => setText(e.target.value)}
/>
```

`npm run dev`

<img width="418" height="232" alt="image" src="https://github.com/user-attachments/assets/3a6a063e-9c34-462b-b9a6-7288f6f2ed42" />


`npm run storybook`


https://github.com/user-attachments/assets/75fc0713-8e43-4614-b49c-659f81873319


