### PR TITLE
Header 컴포넌트 구현

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,0 +1,20 @@
+// Header.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Header from './Header';
+
+const meta: Meta<typeof Header> = {
+  title: 'Components/Header',
+  component: Header,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  render: () => <Header />,
+};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,1 +1,20 @@
-// header component dummy
+'use client';
+
+import React from 'react';
+
+import Button from '../Button/Button';
+
+export default function Header() {
+  const headerStyle = 'bg-blue-200 p-4 flex justify-between w-full';
+  const setStyle = 'gap-2 flex items-center';
+
+  return (
+    <header className={headerStyle}>
+      <Button>BTN</Button>
+      <div className={setStyle}>
+        <Button>더보기</Button>
+        <Button>로그인</Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/Header/header_ui.storybook.tsx
+++ b/src/components/Header/header_ui.storybook.tsx
@@ -1,1 +1,0 @@
-// header storybook dummy file


### PR DESCRIPTION
## 관련 이슈

- close #79 

## PR 설명
#### ✅`Header.tsx`
- `flex`, `justify-between`으로 레이아웃 구성
- `layout.tsx`에서 import하고 실행해볼 수 있음

#### ✅`header_ui.storybook.tsx`
- 임시 파일 삭제 후, `Header.stories.tsx` 생성하여 스토리 작성

**실행 화면**
<img width="870" height="1057" alt="image" src="https://github.com/user-attachments/assets/147ad2aa-0ebb-4e2a-bc8d-ed097133fb43" />

- 추후 SideBar의 열림 여부에 따라 `width` 조정이 필요 (컴포넌트 연결 시 구현 예정)