### PR TITLE
Modal 컴포넌트 추가 및 관련 코드 작성

### DIFF
--- a/src/components/Modal/Modal.style.ts
+++ b/src/components/Modal/Modal.style.ts
@@ -1,0 +1,18 @@
+// Modal.style.ts
+import { tv } from 'tailwind-variants';
+
+export const modalOverlayStyle = tv({
+  base: 'fixed inset-0 z-50 flex items-center justify-center bg-[rgba(0,0,0,0.5)]',
+});
+
+export const modalContentStyle = tv({
+  base: 'bg-gray50 relative h-auto w-auto rounded-2xl shadow-lg',
+});
+
+export const modalHeaderStyle = tv({
+  base: 'flex w-full items-center justify-end px-3 py-3',
+});
+
+export const modalBodyStyle = tv({
+  base: 'p-3',
+});

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { MODAL_TYPE, useModalStore } from '@/stores/modalStore';
+import clsx from 'clsx';
+import { HTMLAttributes, ReactNode, forwardRef, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import Divider from '../Divider/Divider';
+import IconButton from '../IconButton/IconButton';
+import {
+  modalBodyStyle,
+  modalContentStyle,
+  modalHeaderStyle,
+  modalOverlayStyle,
+} from './Modal.style';
+
+interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  children: ReactNode;
+  type: keyof typeof MODAL_TYPE;
+}
+
+const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
+  { className, children, type, ...rest },
+  ref
+) {
+  const { type: openType, close } = useModalStore();
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
+
+  // 포털 렌더링을 위한 div 체크
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      let portalDiv = document.getElementById('modal-root');
+      if (!portalDiv) {
+        portalDiv = document.createElement('div');
+        portalDiv.id = 'modal-root';
+        document.body.appendChild(portalDiv);
+      }
+      setPortalElement(portalDiv);
+    }
+  }, []);
+
+  if (openType !== type) return null;
+  if (!portalElement) return null;
+
+  return createPortal(
+    <div ref={ref} className={clsx(modalOverlayStyle(), className)} onClick={close} {...rest}>
+      <div className={modalContentStyle()} onClick={e => e.stopPropagation()}>
+        <div className={modalHeaderStyle()}>
+          <IconButton
+            icon="IC_Close"
+            size="sm"
+            variant="tertiary"
+            ariaLabel="modal close button"
+            onClick={close}
+          />
+        </div>
+        <Divider color="gray200" />
+        <div className={modalBodyStyle()}>{children}</div>
+      </div>
+    </div>,
+    portalElement
+  );
+});
+
+export default Modal;

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+export const MODAL_TYPE = {
+  EXAMPLE: 'example',
+} as const;
+
+export type ModalType = keyof typeof MODAL_TYPE | null;
+
+interface ModalStore {
+  type: ModalType;
+  props?: Record<string, unknown>;
+  open: (type: ModalType, props?: Record<string, unknown>) => void;
+  close: () => void;
+}
+
+export const useModalStore = create<ModalStore>(set => ({
+  type: null,
+  props: undefined,
+  open: (type, props) => set({ type, props }),
+  close: () => set({ type: null, props: undefined }),
+}));

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,56 @@
+import Button from '@/components/Button/Button';
+import Modal from '@/components/Modal/Modal';
+import { MODAL_TYPE, useModalStore } from '@/stores/modalStore';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+
+const meta = {
+  title: 'Components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: { type: 'text' },
+      description: 'Modal 내부에 표시할 콘텐츠',
+      defaultValue: '모달 내용',
+    },
+    type: {
+      control: {
+        type: 'select',
+        options: Object.values(MODAL_TYPE),
+      },
+      description: 'Modal 타입 (store에서 관리되는 값)',
+    },
+  },
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  render: args => {
+    const StoryWrapper = () => {
+      const { type: openType, open, close } = useModalStore();
+
+      // args.type과 store 연동
+      useEffect(() => {
+        if (openType === args.type) return;
+        close();
+      }, [openType, close]);
+
+      return (
+        <>
+          <Button label="모달 열기" onClick={() => open(args.type)} />
+          <Modal {...args} />
+        </>
+      );
+    };
+
+    return <StoryWrapper />;
+  },
+  args: {
+    children: <div>모달 내용</div>,
+    type: 'EXAMPLE',
+  },
+};


### PR DESCRIPTION
## 관련 이슈

- close #74 

## PR 설명
#### ✅ `Modal.tsx`
- 모달 UI 구현

props | values | description
-- | -- | --
`className` | `string` | -
`children` | `ReactNode` | 모달 내부 콘텐츠 (페이지 컴포넌트)
`type` | `keyof typeof MODAL_TYPE` | 모달 타입 (`modalStore.ts`에 정의됨)

#### ✅ `modalStore.ts`
- 모달 상태 관리(`zustand` 활용)
- 모달 컨텐츠를 만들때마다 해당 파일에서 `MODAL_TYPE`을 추가해줘야합니다.

props | values | description
-- | -- | --
`type` | `ModalType` | 모달에 표시할 컨텐츠를 타입으로 지정
`props` | `Record<string, unknown>` | `type`에 해당하는 내용 전달
`open` | `(type: ModalType) => void` | `isOpen` 상태 set에 이용
`close` | `() => void` | `isOpen` 상태 set에 이용

#### ✅ `ExampleModal.tsx`
- 모달 컨텐츠 예시 컴포넌트

