### PR TITLE
Footer 컴포넌트 구현

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Footer from './Footer';
+
+const meta = {
+  title: 'Components/Footer',
+  component: Footer,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Footer>;
+
+export default meta;
+
+type Story = StoryObj<typeof Footer>;
+
+export const Default: Story = {};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,1 +1,10 @@
-// footer component dummy
+import React from 'react';
+
+const Footer = () => {
+  return (
+    <footer className="flex h-40 items-end justify-center bg-gray-800 p-5 text-center text-sm text-gray-500 dark:text-gray-400">
+      <p>&copy; {new Date().getFullYear()} Linkiving. All rights reserved.</p>
+    </footer>
+  );
+};
+export default Footer;


### PR DESCRIPTION
## 관련 이슈

- close #80 

## PR 설명
#### ✅ `Footer.tsx`
- Footer UI 제작
- 현재로써는 단순 copyright만 보임


## 실행 방법
1. `layout.tsx`에서 `Footer` 컴포넌트를 `import`
2. `body` 태그 내에서 `SearchInput` 컴포넌트 사용

`npm run dev` 실행 결과

<img width="944" height="1043" alt="image" src="https://github.com/user-attachments/assets/af9c31fa-552f-496e-85c4-3a5a1cb849a6" />


`npm run storybook` 실행 결과

<img width="1335" height="331" alt="image" src="https://github.com/user-attachments/assets/800c2f7c-3f17-459a-9477-45de876a04e7" />
