### PR TITLE
CardList 컴포넌트 구현

### DIFF
--- a/src/components/basics/CardList/CardList.tsx
+++ b/src/components/basics/CardList/CardList.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+
+// LinkCard Width = 48 (192px)
+
+interface CardListProps {
+  children: React.ReactNode;
+}
+
+export default function CardList({ children }: CardListProps) {
+  return (
+    <div className="flex w-149 flex-wrap justify-start gap-4 md:w-200 lg:w-251">{children}</div>
+  );
+}

--- a/src/stories/CardList.stories.tsx
+++ b/src/stories/CardList.stories.tsx
@@ -1,0 +1,38 @@
+import CardList from '@/components/basics/CardList/CardList';
+import LinkCard from '@/components/basics/LinkCard/LinkCard';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+const meta = {
+  title: 'Components/Basics/CardList',
+  component: CardList,
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      description: 'CardList 내부에 렌더링할 요소',
+      control: false,
+      table: { disable: true },
+    },
+  },
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof CardList>;
+
+export default meta;
+type Story = StoryObj<typeof CardList>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        {Array.from({ length: 8 }, (_, i) => (
+          <LinkCard
+            key={i}
+            imageUrl=""
+            summary="요약입니다 요약입니다 요약입니다요약입니다 요약입니다 요약입니다."
+            link="https://naver.com"
+            title="예시링크카드"
+          />
+        ))}
+      </>
+    ),
+  },
+};


### PR DESCRIPTION
## 관련 이슈

- close #68

## PR 설명
#### ✅ `CardList.tsx` 
- `grid` 형태로 `children`을 보여주는 `layout` 컴포넌트
- 현재 tailwind 기본 키워드(`sm`, `md`, `lg`)로 화면 크기에 따른 col 개수 임의 지정

## 실행 방법
- `page.tsx`에 임의의 `children` 값 입력

```
"use client";

import CardList from "@/components/CardList/CardList";

export default function Home() {
  return (
    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
      <p> main page</p>
      <CardList>
        {Array.from({ length: 8 }).map((_, i) => (
                <div key={i} className="bg-gray-400 p-4 rounded-md text-center w-60 h-60 hover:cursor-pointer">
                    Card {i + 1}
                </div>
            ))}
      </CardList>
    </div>
  );
}

```

`npm run dev` 실행 화면


https://github.com/user-attachments/assets/4a7ea9e1-5cff-4216-addd-e4c6f4a435dc



`npm run storybook` 실행 화면

https://github.com/user-attachments/assets/699c850b-e12e-4025-ac7d-27af12151fe7


