### PR TITLE
Dropdown 컴포넌트 구현

### DIFF
--- a/src/components/basics/Dropdown/Dropdown.styles.ts
+++ b/src/components/basics/Dropdown/Dropdown.styles.ts
@@ -1,0 +1,16 @@
+import { tv } from 'tailwind-variants';
+
+export const contentStyle = tv({
+  base: 'custom-scrollbar absolute z-10 my-1 max-h-40 max-w-40 divide-gray-900 overflow-hidden overflow-y-auto rounded-md bg-white text-ellipsis whitespace-nowrap text-gray-900 shadow-md',
+});
+
+export const listStyle = tv({
+  base: 'w-full cursor-pointer truncate transition-colors hover:bg-gray-200',
+  variants: {
+    size: {
+      sm: 'px-3 py-1.5 text-sm',
+      md: 'px-4 py-2 text-base',
+      lg: 'px-5 py-3 text-lg',
+    },
+  },
+});

--- a/src/components/basics/Dropdown/Dropdown.tsx
+++ b/src/components/basics/Dropdown/Dropdown.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { forwardRef, useState } from 'react';
+
+import Button from '../Button/Button';
+import { contentStyle, listStyle } from './Dropdown.styles';
+import { useDropdown } from './useDropdown';
+
+export interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  options: DropdownOption[];
+  defaultSelected?: DropdownOption;
+  size?: 'sm' | 'md' | 'lg';
+  onSelect?: (option: DropdownOption) => void;
+}
+
+const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(function Dropdown(
+  { options, defaultSelected = options[0], size = 'sm', onSelect, ...rest },
+  ref
+) {
+  const { isOpen, toggle, close } = useDropdown(ref as React.RefObject<HTMLDivElement>);
+  const [selected, setSelected] = useState<DropdownOption | null>(
+    defaultSelected ?? options[0] ?? null
+  );
+
+  const handleOptionClick = (option: DropdownOption) => {
+    setSelected(option); // 선택 상태 업데이트
+    onSelect?.(option); // 외부 콜백 호출
+    close(); // 메뉴 닫기
+  };
+
+  return (
+    <div ref={ref} className="relative inline-block" {...rest}>
+      <Button
+        label={selected?.label ?? '..'}
+        icon={isOpen ? 'IC_Up' : 'IC_Down'}
+        aria-expanded={isOpen}
+        disabled={options.length === 0}
+        aria-disabled={options.length === 0}
+        size={size}
+        variant="primary"
+        onClick={toggle}
+      />
+      {isOpen && options.length > 0 && (
+        <ul className={contentStyle()} role="menu">
+          <div className="">
+            {options.map(option => (
+              <li
+                className={listStyle({ size })}
+                key={option.value}
+                onClick={() => handleOptionClick(option)}
+                role="menuitem"
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleOptionClick(option);
+                  }
+                }}
+              >
+                {option.label}
+              </li>
+            ))}
+          </div>
+        </ul>
+      )}
+    </div>
+  );
+});
+
+Dropdown.displayName = 'Dropdown';
+export default Dropdown;

--- a/src/components/basics/Dropdown/useDropdown.ts
+++ b/src/components/basics/Dropdown/useDropdown.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useDropdown(ref: React.RefObject<HTMLDivElement>) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // useCallback으로 toggle/close를 메모이제이션하여 핸들러 안정화
+  const toggle = useCallback(() => setIsOpen(prev => !prev), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    // 모바일 외부 클릭 처리
+    const onPointerDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    // ESC 키 처리
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [ref]);
+  return { isOpen, toggle, close };
+}

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,57 @@
+import Dropdown, { DropdownOption } from '@/components/basics/Dropdown/Dropdown';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { type ComponentProps, useState } from 'react';
+
+const options: DropdownOption[] = [
+  { value: 'apple', label: '🍎 Apple' },
+  { value: 'banana', label: '🍌 Banaaaana' },
+  { value: 'cherry', label: '🍒 Cherry' },
+  { value: 'grape', label: '🍇 Grape' },
+  { value: 'watermelon', label: '🍉 Watermelon' },
+  { value: 'peach', label: '🍑 Peach' },
+];
+
+const meta = {
+  title: 'Components/Dropdown',
+  component: Dropdown,
+  tags: ['autodocs'],
+  argTypes: {
+    onSelect: {
+      action: 'option selected',
+      description: '선택된 옵션을 처리하는 콜백 함수',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof Dropdown>;
+
+function InteractiveDropdown(args: ComponentProps<typeof Dropdown>) {
+  const [selected, setSelected] = useState<DropdownOption>(args.defaultSelected ?? options[0]);
+  return (
+    <Dropdown
+      {...args}
+      defaultSelected={selected}
+      onSelect={option => {
+        setSelected(option);
+        args.onSelect?.(option);
+      }}
+    />
+  );
+}
+
+// 인터랙티브 스토리 (render 있음)
+export const Default: Story = {
+  render: args => <InteractiveDropdown {...args} />,
+  args: {
+    options,
+    defaultSelected: options[0],
+    size: 'sm',
+    color: 'blue',
+  },
+};


### PR DESCRIPTION
## 관련 이슈

- close #85

## PR 설명
- 사용자가 버튼 클릭 시 옵션 리스트를 확인하고 항목을 선택할 수 있는 드롭다운 컴포넌트
- 세부 스타일링은 디자인 스펙 확정 후 반영 예정
- 서버 연동을 통한 옵션 데이터 수신을 고려하여 별도 API 핸들링 모듈 추가 예정

#### ✅ `useDropdown.ts`
- `dropdown`의 상태를 관리

반환값 | 타입 | 설명
-- | -- | --
`isOpen` | `boolean` | 드롭다운 메뉴의 열림 여부 상태 (true = 열림, false = 닫힘)
`toggle` | `() => void` | isOpen 상태를 토글 (열기/닫기 전환)하는 함수
`close` | `() => void` | 드롭다운을 강제로 닫는 함수 (isOpen을 false로 설정)

`props` | `type` | 설명
`ref` | `React.RefObject<HTMLDivElement>` | 드롭다운 DOM 요소 참조를 위한 ref. 외부 클릭 감지를 위해 사용

#### ✅ `Dropdown.tsx`
- 선택형 드롭다운 컴포넌트로, 사용자 입력을 트리거로 옵션 리스트를 렌더링
- 선택된 옵션은 버튼에 표시되며, 변경 시 콜백 함수가 실행
- 디자인 요소로 크기(size) 및 색상(color) 옵션을 제공
- 내부에서 useDropdown 훅으로 열림/닫힘 상태 및 외부 클릭 감지를 관리
- 메뉴 UI는 DropdownMenu 컴포넌트로 분리되어 있음

props | type | description
-- | -- | --
`options` | `DropdownOption[]` | 드롭다운에 표시할 옵션 목록
`defaultSelected` | `DropdownOption` | 초기 선택값. 기본값은 `options[0]`
`onSelect` | `(option: DropdownOption) => void` | 사용자가 옵션을 선택했을 때 실행되는 콜백 함수
`size` | `"sm" \| "md" \| "lg"` | 버튼 및 메뉴 항목의 크기 조정 옵션