### PR TITLE
IconButton 컴포넌트 수정

### DIFF
--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,5 +1,5 @@
+import CustomImage from '@/components/icons/TempIcon';
 import type { Meta, StoryObj } from '@storybook/react';
-import Image from 'next/image';
 
 import IconButton from './IconButton';
 
@@ -8,20 +8,10 @@ const meta: Meta<typeof IconButton> = {
   component: IconButton,
   tags: ['autodocs'],
   argTypes: {
-    variant: {
-      control: { type: 'radio' },
-      options: ['solid', 'outline'],
+    onClick: {
+      description: '아이콘만 가지는 버튼입니다.',
+      action: 'clicked',
     },
-    size: {
-      control: { type: 'radio' },
-      options: ['sm', 'md', 'lg'],
-    },
-    radius: {
-      control: { type: 'radio' },
-      options: ['none', 'sm', 'md', 'lg', 'full'],
-    },
-    onClick: { action: 'clicked' },
-    ariaLabel: { control: 'text' },
   },
 };
 
@@ -33,7 +23,8 @@ export const Default: Story = {
     variant: 'solid',
     size: 'md',
     radius: 'md',
-    icon: <Image src="/next.svg" alt="Next.js Icon" width={20} height={20} />,
+    icon: <CustomImage src="file.svg" alt="img" />,
     ariaLabel: 'Icon Button',
+    disabled: false,
   },
 };

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -3,51 +3,58 @@
 import { clsx } from 'clsx';
 import React, { ReactElement } from 'react';
 
-interface IconButtonProps {
+export interface IconButtonProps {
   icon: ReactElement;
   variant?: 'solid' | 'outline';
   size?: 'sm' | 'md' | 'lg';
   radius?: 'none' | 'sm' | 'md' | 'lg' | 'full';
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
-  ariaLabel?: string;
+  ariaLabel: string;
 }
 
-export default function IconButton({
-  icon,
-  size = 'md',
-  radius = 'md',
-  variant = 'solid',
-  onClick,
-  disabled = false,
-  ariaLabel,
-}: IconButtonProps) {
-  const baseStyle = 'inline-flex items-center justify-center focus:bg-gray-300';
-  const variants = {
-    solid: 'bg-gray-400 text-black hover:bg-gray-200',
-    outline: 'border border-gray-200 hover:bg-gray-400',
-  };
-  const sizes = {
-    sm: 'h-8 w-8 text-sm',
-    md: 'h-10 w-10 text-base',
-    lg: 'h-12 w-12 text-lg',
-  };
-  const radiuses = {
-    none: 'rounded-none',
-    sm: 'rounded-sm',
-    md: 'rounded-md',
-    lg: 'rounded-lg',
-    full: 'rounded-full',
-  };
-  const classes = clsx(baseStyle, variants[variant], sizes[size], radiuses[radius], {
-    'bg-gray-400 opacity-50 cursor-not-allowed hover:bg-gray-400 hover:opacity-50 hover:cursor-not-allowed':
-      disabled,
-    'cursor-pointer': !disabled,
-  });
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    { icon, size = 'md', radius = 'md', variant = 'solid', onClick, disabled = false, ariaLabel },
+    ref
+  ) => {
+    const baseStyle = 'inline-flex items-center justify-center focus:bg-gray-300';
+    const variants = {
+      solid: 'bg-gray-400 text-black hover:bg-gray-200',
+      outline: 'border border-gray-200 hover:bg-gray-400',
+    };
+    const sizes = {
+      sm: 'h-8 w-8 text-sm',
+      md: 'h-10 w-10 text-base',
+      lg: 'h-12 w-12 text-lg',
+    };
+    const radiuses = {
+      none: 'rounded-none',
+      sm: 'rounded-sm',
+      md: 'rounded-md',
+      lg: 'rounded-lg',
+      full: 'rounded-full',
+    };
+    const classes = clsx(baseStyle, variants[variant], sizes[size], radiuses[radius], {
+      'bg-gray-400 opacity-50 cursor-not-allowed hover:bg-gray-400 hover:opacity-50 hover:cursor-not-allowed':
+        disabled,
+      'cursor-pointer': !disabled,
+    });
 
-  return (
-    <button className={classes} disabled={disabled} aria-label={ariaLabel} onClick={onClick}>
-      {icon}
-    </button>
-  );
-}
+    return (
+      <button
+        ref={ref}
+        className={classes}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onClick={onClick}
+      >
+        {icon}
+      </button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';
+
+export default IconButton;


### PR DESCRIPTION
## 관련 이슈

- close #115 

## PR 설명
`Image.tsx`
- IconButton.stories.tsx에서 사용할 이미지 컴포넌트 생성

`IconButton.tsx`
- wrapper 패턴 적용할 수 있도록 수정

`IconButton.stories.tsx`
- 스토리에서 불필요한 `argTypes` 삭제
- 스토리에서 임시로 사용하던 `<img>` 를 `<Image>`컴포넌트로 대체