### PR TITLE
Anchor (링크) 컴포넌트 구현

### DIFF
--- a/src/components/Anchor/Anchor.stories.tsx
+++ b/src/components/Anchor/Anchor.stories.tsx
@@ -1,0 +1,41 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Anchor from './Anchor';
+
+const meta = {
+  title: 'Components/Anchor',
+  component: Anchor,
+  tags: ['autodocs'],
+  argTypes: {
+    iconVisible: {
+      control: { type: 'boolean' },
+    },
+    href: { control: 'text' },
+    target: {
+      description: '링크 오픈 방식',
+      control: { type: 'select', options: ['_self', '_blank', '_parent', '_top'] },
+    },
+    rel: {
+      description: '링크 관계/보안/SEO 목적',
+      control: {
+        type: 'select',
+        options: ['noopener', 'noreferrer', 'nofollow', 'noopener noreferrer', 'ugc', 'sponsored'],
+      },
+    },
+    ariaLabel: { description: '접근성', control: 'text' },
+  },
+} satisfies Meta<typeof Anchor>;
+
+export default meta;
+type Story = StoryObj<typeof Anchor>;
+
+export const Default: Story = {
+  args: {
+    iconVisible: true,
+    ariaLabel: 'Example link',
+    children: 'Example Link',
+    href: 'https://example.com',
+    rel: 'noopener',
+    target: '_self',
+  },
+};

--- a/src/components/Anchor/Anchor.tsx
+++ b/src/components/Anchor/Anchor.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import clsx from 'clsx';
+import { HTMLAttributes, ReactNode, forwardRef } from 'react';
+
+import SVGIcon from '../Icons/SVGIcon';
+
+interface AnchorProps
+  extends Omit<HTMLAttributes<HTMLAnchorElement>, 'href' | 'children' | 'target'> {
+  className?: string;
+  iconVisible?: boolean;
+  ariaLabel?: string;
+  children: ReactNode;
+  href: string; // 링크 URL
+  rel?: 'noopener' | 'noreferrer' | 'nofollow' | 'ugc' | 'sponsored' | (string & {});
+  target?: '_self' | '_blank' | '_parent' | '_top';
+}
+
+const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function Anchor(
+  {
+    className,
+    iconVisible = true,
+    children,
+    href,
+    target = '_self',
+    ariaLabel,
+    rel = 'noopener noreferrer',
+    ...rest
+  },
+  ref
+) {
+  const finalRel = (() => {
+    const tokens = new Set((rel ?? '').split(/\s+/).filter(Boolean));
+    if (target === '_blank') tokens.add('noopener'); // window.opener 방지
+    return tokens.size ? Array.from(tokens).join(' ') : undefined;
+  })();
+
+  return (
+    <a
+      ref={ref}
+      href={href}
+      target={target}
+      rel={finalRel}
+      aria-label={ariaLabel}
+      className={clsx('inline-flex items-center gap-1 text-gray-400 hover:underline', className)}
+      {...rest}
+    >
+      {iconVisible && (
+        <SVGIcon
+          icon="IC_LinkOpen"
+          className="mt-[1px] text-gray-400"
+          size="sm"
+          aria-hidden="true"
+        />
+      )}
+      {children}
+    </a>
+  );
+});
+
+export default Anchor;


### PR DESCRIPTION
## 관련 이슈

- close #136 

## PR 설명
- 텍스트 형식의 링크 컴포넌트 구현

### props
props | type | 설명
-- | -- | --
`className?` | `string` | -
`iconVisible?` | `boolean` | `icon` 표시 여부 (아이콘은 지정되어 있음)
`ariaLabel?` | `string` | -
`children` | `ReactNode` | 확정 기획을 전달받지 않아 `ReactNode`로 했으나, `string`으로 변경될 수도 있음
`href` | `string` | 이동할 링크 url
`rel?` | `'noopener'`, `'noreferrer'`, `'nofollow'`, `'ugc'`, `'sponsored'`, `(string&{})` | 현재 문서와 링크된 리소스 간의 관계 (보안,SEO, 의도 명시 목적)
`target?` | `'_self'`, `'_blank'`, `'_parent'`, `'_top'` | 링크 오픈 방식
