### PR TITLE
Spinner 컴포넌트 구현

### DIFF
--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Spinner from './Spinner';
+
+const meta = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'number' },
+    strokeWidth: { control: 'number' },
+    color: { control: 'color' },
+    speed: { control: 'number' },
+  },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {
+  args: {
+    size: 40,
+    strokeWidth: 6,
+    color: '#6f00ff',
+    speed: 1.6,
+  },
+};

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,59 @@
+interface SpinnerProps extends React.SVGProps<SVGSVGElement> {
+  size?: number; // 스피너 가로/세로 크기 (px)
+  strokeWidth?: number; // 테두리 두께(px)
+  color?: string; // 테두리 색상
+  speed?: number; // 회전 속도 (초)
+  ariaLabel?: string;
+}
+
+const Spinner = ({
+  size = 40,
+  strokeWidth = 6,
+  color = '#6f00ff',
+  speed = 1.6,
+  ariaLabel = 'Loading',
+}: SpinnerProps) => {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius; // 원의 둘레 길이
+
+  return (
+    <svg
+      className="animate-spin"
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      style={{
+        animation: `spin ${speed}s linear infinite`,
+      }}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={ariaLabel}
+      focusable="false"
+    >
+      {/* 배경 원 */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="#e3e3e3"
+        strokeWidth={strokeWidth}
+        fill="none"
+      />
+      {/* 바 */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="transparent"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round" // round, butt, square
+        strokeDasharray={circumference} // 전체 바 길이
+        strokeDashoffset={circumference * 0.7} // 보이지 않는 바 길이 (선의 시작 위치를 오프셋만큼 밀어냄)
+      />
+    </svg>
+  );
+};
+
+export default Spinner;


### PR DESCRIPTION
## 관련 이슈

- close #137 

## PR 설명
- 무한 루프로 돌아가는 스피너 컴포넌트 구현

`props` | `type` | 설명
-- | -- | --
`size` | `number` | 크기(px) 지정
`strokeWidth`| `number` | 테두리 두께(px) 지정
`color` | `string` | 색상
`speed` | `number` | 회전 속도(초)