### PR TITLE
Tooltip 컴포넌트 구현

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,90 @@
+// src/components/Tooltip/Tooltip.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Button from '../Button/Button';
+import Tooltip from './Tooltip';
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    side: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+    offset: { control: 'number' },
+    delay: { control: 'number' },
+    content: { control: 'text' },
+    children: { control: false }, // children은 render에서만 구성
+  },
+  args: {
+    content: '툴팁',
+    side: 'bottom',
+    offset: 12,
+    delay: 80,
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Bottom: Story = {
+  args: {
+    content: '저장 버튼',
+    side: 'bottom',
+  },
+  render: args => (
+    <Tooltip {...args}>
+      <Button variant="primary" label="저장" />
+    </Tooltip>
+  ),
+};
+
+export const Top: Story = {
+  args: {
+    content: '툴팁이 위에 표시됩니다',
+    side: 'top',
+  },
+  render: args => (
+    <Tooltip {...args}>
+      <Button variant="outline" label="위쪽" />
+    </Tooltip>
+  ),
+};
+
+export const Left: Story = {
+  args: {
+    content: '툴팁이 왼쪽에 표시됩니다',
+    side: 'left',
+  },
+  render: args => (
+    <Tooltip {...args}>
+      <Button variant="ghost" label="왼쪽" />
+    </Tooltip>
+  ),
+};
+
+export const Right: Story = {
+  args: {
+    content: '툴팁이 오른쪽에 표시됩니다',
+    side: 'right',
+  },
+  render: args => (
+    <Tooltip {...args}>
+      <Button variant="ghost" label="오른쪽" />
+    </Tooltip>
+  ),
+};
+
+export const DisabledButton: Story = {
+  args: {
+    content: '활성화되지 않은 상태',
+    side: 'top',
+  },
+  render: args => (
+    <Tooltip {...args}>
+      <Button variant="outline" label="비활성" disabled />
+    </Tooltip>
+  ),
+};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import clsx from 'clsx';
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { tv } from 'tailwind-variants';
+
+type Side = 'top' | 'bottom' | 'left' | 'right';
+type Timer = ReturnType<typeof setTimeout>;
+
+const bubbleStyles = tv({
+  base: [
+    'pointer-events-none absolute z-50 rounded-lg',
+    'border bg-white text-black shadow-lg',
+    'px-3 py-2 text-xs font-medium tracking-wide',
+    'leading-tight whitespace-nowrap',
+  ].join(' '),
+});
+
+export interface TooltipProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'content' | 'children'> {
+  // 동작 관련 props
+  content: React.ReactNode;
+  side?: Side;
+  offset?: number;
+  delay?: number;
+  children: React.ReactNode;
+
+  // 스타일링 관련 props
+  className?: string;
+
+  // 콜백 관련 props (옵션으로 확장 가능)
+  onOpenChange?: (open: boolean) => void;
+}
+
+const Tooltip = React.forwardRef<HTMLSpanElement, TooltipProps>(function Tooltip(
+  {
+    content,
+    side = 'bottom',
+    offset = 12,
+    delay = 80,
+    className,
+    children,
+    onOpenChange,
+    onMouseEnter,
+    onMouseLeave,
+    onFocus,
+    onBlur,
+    ...rest
+  },
+  ref
+) {
+  const id = useId();
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef<Timer | null>(null);
+
+  const setOpenSafe = (next: boolean) => {
+    setOpen(next);
+    onOpenChange?.(next);
+  };
+
+  const show = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setOpenSafe(true), delay);
+  };
+
+  const hide = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setOpenSafe(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const getPositionStyle = (): React.CSSProperties => {
+    switch (side) {
+      case 'top':
+        return { bottom: `calc(100% + ${offset}px)`, left: '50%', transform: 'translateX(-50%)' };
+      case 'bottom':
+        return { top: `calc(100% + ${offset}px)`, left: '50%', transform: 'translateX(-50%)' };
+      case 'left':
+        return { right: `calc(100% + ${offset}px)`, top: '50%', transform: 'translateY(-50%)' };
+      case 'right':
+        return { left: `calc(100% + ${offset}px)`, top: '50%', transform: 'translateY(-50%)' };
+      default:
+        return {};
+    }
+  };
+
+  // 사용자 이벤트 핸들러와 합성
+  const handleMouseEnter: React.MouseEventHandler<HTMLSpanElement> = e => {
+    show();
+    onMouseEnter?.(e);
+  };
+  const handleMouseLeave: React.MouseEventHandler<HTMLSpanElement> = e => {
+    hide();
+    onMouseLeave?.(e);
+  };
+  const handleFocus: React.FocusEventHandler<HTMLSpanElement> = e => {
+    show();
+    onFocus?.(e);
+  };
+  const handleBlur: React.FocusEventHandler<HTMLSpanElement> = e => {
+    hide();
+    onBlur?.(e);
+  };
+
+  const classes = bubbleStyles();
+
+  return (
+    <span
+      ref={ref}
+      className="relative inline-flex"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onFocus={handleFocus} // focus/blur는 버블링됨
+      onBlur={handleBlur}
+      // tabIndex 없음: 래퍼는 포커스 불가 → 이중 탭 스톱 방지
+      {...rest}
+    >
+      {children}
+
+      {open && (
+        <span
+          id={id}
+          role="tooltip"
+          style={getPositionStyle()}
+          className={clsx(classes, className)}
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+});
+
+export default Tooltip;


### PR DESCRIPTION
## 관련 이슈

- close #84 

## PR 설명
- 버튼 hover 시 말풍선을 띄워주는 **Tooltip 컴포넌트** 구현
- `side`, `offset`, `delay` 등의 props를 통해 위치와 표시 간격 조절 가능
- Storybook에 Tooltip 예시 스토리 추가 (Button 컴포넌트와 함께 사용)

### ✅ `Tooltip.tsx`
- Tooltip UI 컴포넌트 구현
- 방향(`top`, `bottom`, `left`, `right`) 지정 가능
- `offset`을 통해 버튼과의 간격 설정
- `delay` 옵션으로 표시 시간 지연 제어

### ✅ `Tooltip.stories.tsx`
- Storybook용 Tooltip 예시 스토리 작성
- Button 컴포넌트와 조합하여 다양한 방향/옵션 확인 가능
- `argTypes`를 설정하여 Storybook Controls에서 옵션 실험 가능

## 실행 방법
`page.tsx`를 아래와 같이 임시로 작성
```
'use client';

import Button from '@/components/Button/Button';
import Tooltip from '@/components/Tooltip/Tooltip';

export default function TooltipDemoPage() {
  return (
    <main className="min-h-screen bg-white p-10">
      <div className="flex items-center gap-8">
        {/* 기본 저장 버튼 */}
        <Tooltip content="이 버튼을 클릭하면 저장됩니다" side="bottom" offset={0} delay={500}>
          <Button variant="primary">저장</Button>
        </Tooltip>

        {/* 설정 버튼 */}
        <Tooltip content="설정 열기" side="bottom" offset={5} delay={300}>
          <Button variant="outline" icon="⚙️">
            설정
          </Button>
        </Tooltip>

        {/* 정보 버튼 */}
        <Tooltip content="추가 정보 보기" side="bottom" offset={10}>
          <Button variant="ghost" icon="ℹ️" iconPosition="left">
            정보
          </Button>
        </Tooltip>
      </div>
    </main>
  );
}
```