### PR TITLE
tailwind 정렬 세팅

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -20,5 +20,6 @@
   "trailingComma": "es5",
   "arrowParens": "avoid",
   "endOfLine": "lf",
-  "plugins": ["@trivago/prettier-plugin-sort-imports"]
+  "plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["clsx", "tv"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "15.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "tailwind-variants": "^3.1.1",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -50,7 +51,8 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
         "playwright": "^1.52.0",
-        "prettier": "3.6.2",
+        "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.7.1",
         "storybook": "^8.6.13",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -14895,6 +14897,85 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.1.tgz",
+      "integrity": "sha512-Bzv1LZcuiR1Sk02iJTS1QzlFNp/o5l2p3xkopwOrbPmtMeh3fK9rVW5M3neBQzHq+kGKj/4LGQMTNcTH4NGPtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -16747,11 +16828,29 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tailwind-variants": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-3.1.1.tgz",
+      "integrity": "sha512-ftLXe3krnqkMHsuBTEmaVUXYovXtPyTK7ckEfDRXS8PBZx0bAUas+A0jYxuKA5b8qg++wvQ3d2MQ7l/xeZxbZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.x",
+        "pnpm": ">=7.x"
+      },
+      "peerDependencies": {
+        "tailwind-merge": ">=3.0.0",
+        "tailwindcss": "*"
+      },
+      "peerDependenciesMeta": {
+        "tailwind-merge": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "next": "15.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "tailwind-variants": "^3.1.1",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
@@ -66,7 +67,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "playwright": "^1.52.0",
-    "prettier": "3.6.2",
+    "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.7.1",
     "storybook": "^8.6.13",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 // homepage (new chat page)
 export default function homepage() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
       <p> home page</p>
       <Link href="/chat">Chat Page</Link>
       <Link href="/allLink">All link Page</Link>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -38,8 +38,8 @@ export default function Button({
 
   // 클래스 조합부
   const classes = clsx(baseStyle, variants[variant], sizes[size], {
-    'bg-gray-400 opacity-50 cursor-not-allowed': disabled,
-    'hover:bg-gray-400 hover:opacity-50 hover:cursor-not-allowed': disabled,
+    'cursor-not-allowed bg-gray-400 opacity-50': disabled,
+    'hover:cursor-not-allowed hover:bg-gray-400 hover:opacity-50': disabled,
   });
 
   // 버튼 실제 출력 부분

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -36,7 +36,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       full: 'rounded-full',
     };
     const classes = clsx(baseStyle, variants[variant], sizes[size], radiuses[radius], {
-      'bg-gray-400 opacity-50 cursor-not-allowed hover:bg-gray-400 hover:opacity-50 hover:cursor-not-allowed':
+      'cursor-not-allowed bg-gray-400 opacity-50 hover:cursor-not-allowed hover:bg-gray-400 hover:opacity-50':
         disabled,
       'cursor-pointer': !disabled,
     });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -53,7 +53,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function TextField(
     sizeStyles[size],
     radiusStyles[radius],
     variantStyles[variant],
-    disabled && 'opacity-50 pointer-events-none'
+    disabled && 'pointer-events-none opacity-50'
   );
 
   return (
@@ -64,7 +64,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function TextField(
         value={value}
         placeholder={placeholder}
         disabled={disabled}
-        className="flex-1 min-w-0 bg-transparent outline-none"
+        className="min-w-0 flex-1 bg-transparent outline-none"
         onChange={onChange}
         {...rest}
       />

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -22,7 +22,7 @@ export default function Label({ text, htmlFor, size = 'md', required = false }: 
   return (
     <label htmlFor={htmlFor} className={classes}>
       {required && (
-        <span aria-hidden="true" className="text-red-500 ml-1">
+        <span aria-hidden="true" className="ml-1 text-red-500">
           *{' '}
         </span>
       )}


### PR DESCRIPTION
## 관련 이슈

- close #163

## PR 설명
- ❗실행에 앞서 `npm install`을 진행해주세요
- `tailwind` 키워드 정렬을 위한 prettier 플러그인 및 `tv` 라이브러리를 설치합니다.
- `prettier-plugin-tailwindcss` : tailwind 문자열을 정렬합니다.
- `tv` : `tailwind variant`의 약자로, tailwind variant를 간편하게 정의하도록 합니다.
위의 플러그인으로는 변수에 할당한 tailwind를 정렬하지 못한다는 단점이 있습니다. 이를 해결하고, 더 깔끔한 스타일링 코드를 작성하기 위해 `tv`를 설치하여 사용합니다.
- 스타일링 코드 작성 방식을 정리했으니, [문서](https://www.notion.so/goder/237ef7829e2c80eab180ec8122d6452c)를 확인해주세요

### `.prettierrc`
- tailwindcss 플러그인을 추가하고, `clsx`와 `tv`로 감싼 tailwind를 정렬하도록 지정