### PR TITLE
Button, IconButton 컴포넌트 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ]
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.75.7",
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
@@ -36,7 +37,6 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@svgr/webpack": "^8.1.0",
     "@chromatic-com/storybook": "^3.2.6",
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
@@ -49,6 +49,7 @@
     "@storybook/nextjs": "^8.6.13",
     "@storybook/react": "^8.6.13",
     "@storybook/test": "^8.6.13",
+    "@svgr/webpack": "^8.1.0",
     "@tailwindcss/postcss": "^4",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.1.8)(react@19.1.0)
       '@tanstack/react-query':
         specifier: ^5.75.7
         version: 5.83.0(react@19.1.0)
@@ -1425,6 +1428,24 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -6961,6 +6982,19 @@ snapshots:
       webpack-hot-middleware: 2.26.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
 
   '@rollup/pluginutils@5.2.0(rollup@4.45.1)':
     dependencies:

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -7,7 +7,7 @@ import Button from './Button';
 const ICONS = Object.keys(IconMap);
 
 const meta = {
-  title: 'Components/Button',
+  title: 'Components/Buttons/Button',
   component: Button,
   tags: ['autodocs'],
   parameters: {
@@ -24,7 +24,12 @@ const meta = {
     },
     variant: {
       control: 'inline-radio',
-      options: ['primary', 'outline', 'ghost'],
+      options: ['primary', 'secondary', 'tertiary', 'neutral'],
+      table: { type: { summary: 'string' } },
+    },
+    radius: {
+      control: 'inline-radio',
+      options: ['md', 'full'],
       table: { type: { summary: 'string' } },
     },
     size: {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Slot } from '@radix-ui/react-slot';
 import { clsx } from 'clsx';
 import React from 'react';
 import { tv } from 'tailwind-variants';
@@ -8,46 +9,55 @@ import SVGIcon from '../Icons/SVGIcon';
 import { IconMapTypes, IconSizeTypes } from '../Icons/icons';
 
 const styles = tv({
-  base: 'inline-flex items-center justify-center rounded font-medium whitespace-nowrap transition-all duration-150 outline-none',
+  base: 'btn',
   variants: {
     variant: {
-      primary: 'cursor-pointer bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700',
-      outline:
-        'cursor-pointer border border-gray-300 text-gray-700 hover:bg-gray-50 active:bg-gray-100',
-      ghost: 'cursor-pointer bg-transparent text-gray-700 hover:bg-gray-100 active:bg-gray-200',
+      primary: 'btn-primary',
+      secondary: 'btn-secondary',
+      tertiary: 'btn-tertiary',
+      neutral: 'btn-neutral',
+    },
+    radius: {
+      md: 'rounded-lg',
+      full: 'rounded-full',
     },
     size: {
-      sm: 'h-8 px-4 py-1.5 text-sm',
-      md: 'h-10 px-5 py-2 text-base',
-      lg: 'h-12 px-6 py-3 text-lg',
+      sm: 'btn-sm',
+      md: 'btn-md',
+      lg: 'btn-lg',
     },
     disabled: {
-      true: 'pointer-events-none cursor-not-allowed bg-gray-400 opacity-50',
+      true: 'btn-disabled',
       false: '',
     },
   },
 });
 
 export interface ButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'disabled' | 'onClick' | 'children'> {
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'disabled' | 'onClick'> {
+  asChild?: boolean;
   className?: string;
   icon?: IconMapTypes;
   iconPosition?: 'left' | 'right';
   label?: string;
-  variant?: 'primary' | 'outline' | 'ghost';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'neutral';
+  radius?: 'md' | 'full';
   size?: 'sm' | 'md' | 'lg';
   disabled?: boolean;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {
+    asChild = false,
+    children,
     className,
     icon,
     iconPosition = 'left',
     label,
     type = 'button',
     variant = 'primary',
+    radius = 'md',
     size = 'md',
     disabled = false,
     onClick,
@@ -58,17 +68,21 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   // STYLES
   const classes = styles({
     variant,
+    radius,
     size,
     disabled,
   });
   const iconSize: IconSizeTypes = size;
 
+  // 인터랙션 요소 중첩 방지를 위해 Slot 적용
+  const Comp = asChild ? Slot : 'button';
+
   // RENDERING
   const buttonIcon = icon ? (
     <span
       className={clsx('flex-shrink-0', {
-        'mr-2': iconPosition === 'left',
-        'ml-2': iconPosition === 'right',
+        'mr-1': iconPosition === 'left',
+        'ml-1': iconPosition === 'right',
       })}
     >
       <SVGIcon icon={icon} size={iconSize} />
@@ -94,7 +108,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   }
 
   return (
-    <button
+    <Comp
       ref={ref}
       className={clsx(classes, className)}
       disabled={disabled}
@@ -103,8 +117,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       onClick={onClick}
       {...rest}
     >
-      {content}
-    </button>
+      {asChild ? children : content}
+    </Comp>
   );
 });
 

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import IconButton from './IconButton';
 
 const meta = {
-  title: 'Components/IconButton',
+  title: 'Components/Buttons/IconButton',
   component: IconButton,
   tags: ['autodocs'],
   parameters: {
@@ -21,7 +21,6 @@ const meta = {
       table: { type: { summary: 'IconMapTypes' } },
     },
     type: { control: 'inline-radio', table: { type: { summary: 'string' } } },
-    radius: { control: 'inline-radio', table: { type: { summary: 'string' } } },
     className: { table: { disable: true } },
     onClick: { action: 'clicked', table: { disable: true } },
   },
@@ -32,7 +31,7 @@ type Story = StoryObj<typeof IconButton>;
 
 export const Default: Story = {
   args: {
-    variant: 'ghost',
+    variant: 'primary',
     size: 'md',
     icon: 'IC_AllLink',
     ariaLabel: 'Icon Button',

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Slot } from '@radix-ui/react-slot';
 import { clsx } from 'clsx';
 import React from 'react';
 import { tv } from 'tailwind-variants';
@@ -8,51 +9,48 @@ import SVGIcon from '../Icons/SVGIcon';
 import { IconMapTypes, IconSizeTypes } from '../Icons/icons';
 
 const styles = tv({
-  base: 'inline-flex cursor-pointer items-center justify-center whitespace-nowrap transition-all duration-150 outline-none focus:bg-gray-300',
+  base: 'iconBtn',
   variants: {
     variant: {
-      ghost: 'bg-gray-50 text-black hover:bg-blue-50 active:bg-blue-100',
-      outline: 'border border-gray-200 text-black hover:bg-gray-400 active:bg-gray-500',
+      primary: 'iconBtn-primary',
+      secondary: 'iconBtn-secondary',
+      tertiary: 'iconBtn-tertiary',
+      neutral: 'iconBtn-neutral',
     },
     size: {
-      sm: 'h-6 w-6 p-1',
-      md: 'h-8 w-8 p-2',
-      lg: 'h-10 w-10 p-3',
-    },
-    radius: {
-      sm: 'rounded-sm',
-      md: 'rounded-md',
-      lg: 'rounded-lg',
-      full: 'rounded-full',
+      sm: 'iconBtn-sm',
+      md: 'iconBtn-md',
+      lg: 'iconBtn-lg',
     },
     disabled: {
-      true: 'pointer-events-none cursor-not-allowed bg-gray-400 opacity-50',
+      true: 'iconBtn-disabled',
       false: '',
     },
   },
 });
 
 export interface IconButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick' | 'children'> {
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick'> {
+  asChild?: boolean;
   className?: string;
   icon: IconMapTypes; // icon 타입을 .svg 파일로 강제
   type?: 'button' | 'submit';
-  variant?: 'ghost' | 'outline';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'neutral';
   size?: 'sm' | 'md' | 'lg';
-  radius?: 'sm' | 'md' | 'lg' | 'full';
   disabled?: boolean;
   ariaLabel: string;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(
   {
+    asChild = false,
+    children,
     className,
     icon,
     type = 'button',
-    variant = 'ghost',
+    variant = 'primary',
     size = 'md',
-    radius = 'full',
     disabled = false,
     ariaLabel,
     onClick,
@@ -61,11 +59,14 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function
   ref
 ) {
   // STYLES
-  const classes = styles({ variant, size, radius, disabled });
+  const classes = styles({ variant, size, disabled });
   const iconSize: IconSizeTypes = size;
 
+  // 인터랙션 요소 중첩 방지를 위해 Slot 적용
+  const Comp = asChild ? Slot : 'button';
+
   return (
-    <button
+    <Comp
       ref={ref}
       className={clsx(className, classes)}
       disabled={disabled}
@@ -74,8 +75,12 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function
       onClick={onClick}
       {...rest}
     >
-      <SVGIcon icon={icon} size={iconSize} className="flex-shrink-0" aria-hidden="true" />
-    </button>
+      {asChild ? (
+        children
+      ) : (
+        <SVGIcon icon={icon} size={iconSize} className="flex-shrink-0" aria-hidden="true" />
+      )}
+    </Comp>
   );
 });
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -16,7 +16,7 @@ export default function Tag({ label, onDelete }: TagProps) {
       {onDelete && (
         <IconButton
           icon="IC_Close"
-          variant="ghost"
+          variant="primary"
           size="sm"
           ariaLabel={label || `${label} 태그 삭제`}
           onClick={onDelete}

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -48,7 +48,7 @@ export const Top: Story = {
   },
   render: args => (
     <Tooltip {...args}>
-      <Button variant="outline" label="위쪽" />
+      <Button variant="primary" label="위쪽" />
     </Tooltip>
   ),
 };
@@ -60,7 +60,7 @@ export const Left: Story = {
   },
   render: args => (
     <Tooltip {...args}>
-      <Button variant="ghost" label="왼쪽" />
+      <Button variant="primary" label="왼쪽" />
     </Tooltip>
   ),
 };
@@ -72,7 +72,7 @@ export const Right: Story = {
   },
   render: args => (
     <Tooltip {...args}>
-      <Button variant="ghost" label="오른쪽" />
+      <Button variant="primary" label="오른쪽" />
     </Tooltip>
   ),
 };
@@ -84,7 +84,7 @@ export const DisabledButton: Story = {
   },
   render: args => (
     <Tooltip {...args}>
-      <Button variant="outline" label="비활성" disabled />
+      <Button variant="primary" label="비활성" disabled />
     </Tooltip>
   ),
 };

--- a/src/styles/compStyles/buttonStyles.css
+++ b/src/styles/compStyles/buttonStyles.css
@@ -1,0 +1,92 @@
+@layer components {
+  .btn {
+    @apply inline-flex cursor-pointer items-center justify-center rounded-full whitespace-nowrap transition-all duration-150;
+  }
+
+  .btn-primary {
+    @apply border;
+    background-color: var(--container-primary-default);
+    color: var(--label-primary-default);
+    border-color: var(--border-primary-default);
+    &:hover {
+      background-color: var(--container-primary-hover);
+      color: var(--label-primary-focus);
+      border-color: var(--border-primary-hover);
+    }
+    &:focus {
+      background-color: var(--container-primary-focus);
+      color: var(--label-primary-focus);
+      border-color: var(--border-primary-focus);
+    }
+  }
+  .btn-secondary {
+    @apply border;
+    background-color: var(--container-secondary-default);
+    color: var(--label-secondary-default);
+    border-color: var(--border-secondary-default);
+    &:hover {
+      background-color: var(--container-secondary-hover);
+      color: var(--label-secondary-hover);
+      border-color: var(--border-secondary-hover);
+    }
+    &:focus {
+      background-color: var(--container-secondary-focus);
+      color: var(--label-secondary-focus);
+      border-color: var(--border-secondary-focus);
+    }
+  }
+  .btn-tertiary {
+    @apply border;
+    background-color: var(--container-tertiary-default);
+    color: var(--label-tertiary-default);
+    border-color: var(--border-tertiary-default);
+    &:hover {
+      background-color: var(--container-tertiary-hover);
+      color: var(--label-tertiary-hover);
+      border-color: var(--border-tertiary-hover);
+    }
+    &:focus {
+      background-color: var(--container-tertiary-focus);
+      color: var(--label-tertiary-focus);
+      border-color: var(--border-tertiary-focus);
+    }
+  }
+  .btn-neutral {
+    background-color: var(--container-neutral-onpanel-default);
+    color: var(--label-neutral-default);
+    border-color: var(--border-neutral-default);
+    &:hover {
+      background-color: var(--container-neutral-onpanel-hover);
+      color: var(--label-neutral-hover);
+      border-color: var(--border-neutral-hover);
+    }
+    &:focus {
+      background-color: var(--container-neutral-onpanel-focus);
+      color: var(--label-neutral-focus);
+      border-color: var(--border-neutral-focus);
+    }
+  }
+
+  .btn-sm {
+    @apply px-3 py-2;
+    font-size: var(--text-label-small-size);
+    line-height: var(--text-label-small-line-height);
+    font-weight: var(--text-label-small-weight);
+  }
+  .btn-md {
+    @apply px-4 py-[10px];
+    font-size: var(--text-label-medium-size);
+    line-height: var(--text-label-medium-line-height);
+    font-weight: var(--text-label-medium-weight);
+  }
+  .btn-lg {
+    @apply px-5 py-3;
+    font-size: var(--text-label-large-size);
+    line-height: var(--text-label-large-line-height);
+    font-weight: var(--text-label-large-weight);
+  }
+
+  .btn-disabled {
+    @apply cursor-not-allowed opacity-30;
+  }
+}

--- a/src/styles/compStyles/iconButtonStyles.css
+++ b/src/styles/compStyles/iconButtonStyles.css
@@ -1,0 +1,83 @@
+@layer components {
+  .iconBtn {
+    @apply flex cursor-pointer items-center justify-center rounded-full transition-all duration-150;
+  }
+
+  .iconBtn-primary {
+    @apply border;
+    background-color: var(--container-primary-default);
+    color: var(--label-primary-default);
+    border-color: var(--border-primary-default);
+    &:hover {
+      background-color: var(--container-primary-hover);
+      color: var(--label-primary-focus);
+      border-color: var(--border-primary-hover);
+    }
+    &:focus {
+      background-color: var(--container-primary-focus);
+      color: var(--label-primary-focus);
+      border-color: var(--border-primary-focus);
+    }
+  }
+  .iconBtn-secondary {
+    @apply border;
+    background-color: var(--container-secondary-default);
+    color: var(--label-secondary-default);
+    border-color: var(--border-secondary-default);
+    &:hover {
+      background-color: var(--container-secondary-hover);
+      color: var(--label-secondary-hover);
+      border-color: var(--border-secondary-hover);
+    }
+    &:focus {
+      background-color: var(--container-secondary-focus);
+      color: var(--label-secondary-focus);
+      border-color: var(--border-secondary-focus);
+    }
+  }
+  .iconBtn-tertiary {
+    @apply border;
+    background-color: var(--container-tertiary-default);
+    color: var(--label-tertiary-default);
+    border-color: var(--border-tertiary-default);
+    &:hover {
+      background-color: var(--container-tertiary-hover);
+      color: var(--label-tertiary-hover);
+      border-color: var(--border-tertiary-hover);
+    }
+    &:focus {
+      background-color: var(--container-tertiary-focus);
+      color: var(--label-tertiary-focus);
+      border-color: var(--border-tertiary-focus);
+    }
+  }
+  .iconBtn-neutral {
+    background-color: var(--container-neutral-onpanel-default);
+    color: var(--label-neutral-default);
+    border-color: var(--border-neutral-default);
+    &:hover {
+      background-color: var(--container-neutral-onpanel-hover);
+      color: var(--label-neutral-hover);
+      border-color: var(--border-neutral-hover);
+    }
+    &:focus {
+      background-color: var(--container-neutral-onpanel-focus);
+      color: var(--label-neutral-focus);
+      border-color: var(--border-neutral-focus);
+    }
+  }
+
+  .iconBtn-sm {
+    @apply h-8 w-8;
+  }
+  .iconBtn-md {
+    @apply h-9 w-9;
+  }
+  .iconBtn-lg {
+    @apply h-10 w-10;
+  }
+
+  .iconBtn-disabled {
+    @apply cursor-not-allowed opacity-30;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,8 @@
 
 @import './colors.css';
 @import './tokens.css';
+@import './compStyles/buttonStyles.css';
+@import './compStyles/iconButtonStyles.css';
 
 /* === GLOBAL DEFAULT STYLES === */
 :root {


### PR DESCRIPTION
## 관련 이슈

- close #183

## PR 설명
- `pnpm install` 필요: `@radix-ui/react-slot` 설치

### `*.stories.tsx`
- 최신 버튼 `variants` 반영
- `Components/Buttons/` 폴더 생성

### `Button.tsx`, `IconButton.tsx`
- `styles`에 디자인 토큰 반영
- `Slot` 컴포넌트로 변경 (추후 링크 연결 등 인터랙션 중첩 가능성이 있어 수정)
    - ❗ 인터랙션 버튼 래퍼를 만들경우, `asChild`를 작성하여 제작합니다. 
- 최신 `variants` 및 `radius` 반영

### `buttonStyles.css`, `iconButtonStyles.css`
- `tokens.css`의 디자인토큰 활용하여 tailwind 키워드 작성
- `globals.css`에서 `import` 하여 사용
    - 컴포넌트 내에서 직접 불러오려고 시도했으나, storybook 충돌이 발생하여 globals.css로 진행
    - `styles/compStyles/` 폴더 하위에 컴포넌트 css 파일을 둠
