### PR TITLE
Button 컴포넌트에 tertiary border 추가

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -6,7 +6,7 @@ export const style = tv({
     variant: {
       primary: 'btn-primary bg-btn-primary border-btn-primary text-btn-primary border',
       secondary: 'btn-secondary bg-btn-secondary border-btn-secondary text-btn-secondary border',
-      tertiary: 'btn-tertiary bg-btn-tertiary text-btn-tertiary',
+      tertiary: 'btn-tertiary bg-btn-tertiary border-btn-tertiary text-btn-tertiary border',
       neutral: 'btn-neutral bg-btn-neutral text-btn-neutral',
     },
     contextStyle: {


### PR DESCRIPTION
## 관련 이슈

- close #204 

## PR 설명
- `Button` 컴포넌트의 `tertiary` variant에 border가 빠져, 해당 스타일 수정
