### PR TITLE
LinkIconButton 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,7 +70,6 @@ const config = [
             {
               case: 'camel',
               target: '**/hooks/**', // target "hooks" folder
-              patterns: '^use', // file names begin with "use".
             },
           ],
         },

--- a/src/components/IconButton/Wrappers/LinkIconButton.tsx
+++ b/src/components/IconButton/Wrappers/LinkIconButton.tsx
@@ -1,0 +1,29 @@
+import SVGIcon from '@/components/Icons/SVGIcon';
+import { getSafeUrl } from '@/hooks/util/getSafeUrl';
+import Link from 'next/link';
+
+import IconButton, { IconButtonProps } from '../IconButton';
+
+interface LinkIconButtonProps extends Omit<IconButtonProps, 'ariaLabel'> {
+  href: string;
+  ariaLabel: string;
+}
+
+const LinkIconButton = ({ href, icon, size, ariaLabel }: LinkIconButtonProps) => {
+  if (!icon)
+    console.error('LinkIconButton: Either icon or label should be provided for accessibility');
+
+  const safeUrl = getSafeUrl(href);
+  const isExternal = /^https?:\/\//i.test(safeUrl);
+  const linkProps = isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+
+  return (
+    <IconButton asChild size={size} icon={icon} ariaLabel={ariaLabel}>
+      <Link href={safeUrl} {...linkProps}>
+        <SVGIcon icon={icon} size={size} />
+      </Link>
+    </IconButton>
+  );
+};
+
+export default LinkIconButton;

--- a/src/hooks/util/getSafeUrl.ts
+++ b/src/hooks/util/getSafeUrl.ts
@@ -1,0 +1,10 @@
+export function getSafeUrl(link: string) {
+  // 절대 URL(http/https)이거나 상대 경로(/)로 시작하면 안전한 것으로 간주
+  const isAbsoluteUrl = /^https?:\/\//i.test(link);
+  const isRelativePath = link.startsWith('/');
+  const isHashLink = link.startsWith('#');
+  const isRelativeFile = link.startsWith('./') || link.startsWith('../');
+
+  const safeHref = isAbsoluteUrl || isRelativePath || isHashLink || isRelativeFile ? link : '';
+  return safeHref;
+}

--- a/src/stories/LinkIconButton.stories.tsx
+++ b/src/stories/LinkIconButton.stories.tsx
@@ -1,0 +1,30 @@
+import LinkIconButton from '@/components/IconButton/Wrappers/LinkIconButton';
+import { IconMap } from '@/components/Icons/icons';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/LinkIconButton',
+  component: LinkIconButton,
+  tags: ['autodocs'],
+  argTypes: {
+    onClick: { action: '버튼 클릭됨' },
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    type: { control: 'inline-radio' },
+    variant: { control: 'inline-radio' },
+    contextStyle: { control: 'inline-radio' },
+    icon: { control: 'text', options: Object.keys(IconMap) },
+    href: { control: 'text' },
+  },
+} satisfies Meta<typeof LinkIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    href: 'https://example.com',
+    icon: 'IC_AllLink',
+    size: 'md',
+    ariaLabel: '전체 링크 버튼',
+  },
+};


### PR DESCRIPTION
## 관련 이슈

- close #214

## PR 설명
- `Link`태그를 감싸는 `LinkIconButton` 컴포넌트 구현
- `href`로 링크를 전달