### PR TITLE
Label 컴포넌트 구현

### DIFF
--- a/src/components/basics/Button/Button.style.ts
+++ b/src/components/basics/Button/Button.style.ts
@@ -19,9 +19,9 @@ export const style = tv({
       full: 'rounded-full',
     },
     size: {
-      sm: 'font-label-sm px-3 py-2',
-      md: 'font-label-md px-4 py-[10px]',
-      lg: 'font-label-lg px-5 py-3',
+      sm: 'px-3 py-2',
+      md: 'px-4 py-[10px]',
+      lg: 'px-5 py-3',
     },
     disabled: {
       true: 'cursor-not-allowed opacity-30',

--- a/src/components/basics/Button/Button.tsx
+++ b/src/components/basics/Button/Button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Label from '@/components/basics/Label/Label';
 import { Slot } from '@radix-ui/react-slot';
 import { clsx } from 'clsx';
 import React from 'react';
@@ -66,7 +67,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       ) : (
         <div className="flex items-center gap-x-1">
           {icon && <SVGIcon icon={icon} size={iconSize} />}
-          <span className={icon ? 'pr-1' : ''}>{label}</span>
+          <Label textSize={size} className={icon ? 'pr-1' : ''}>
+            {label}
+          </Label>
         </div>
       )}
     </Comp>

--- a/src/components/basics/Label/Label.style.ts
+++ b/src/components/basics/Label/Label.style.ts
@@ -1,0 +1,13 @@
+import { tv } from 'tailwind-variants';
+
+export const style = tv({
+  base: '',
+  variants: {
+    textSize: {
+      sm: 'font-label-sm',
+      md: 'font-label-md',
+      lg: 'font-label-lg',
+      xl: 'font-label-xl',
+    },
+  },
+});

--- a/src/components/basics/Label/Label.tsx
+++ b/src/components/basics/Label/Label.tsx
@@ -1,32 +1,26 @@
-'use client';
+import clsx from 'clsx';
+import React, { HTMLAttributes, forwardRef } from 'react';
 
-import { clsx } from 'clsx';
-import React from 'react';
+import { style } from './Label.style';
 
-interface LabelProps {
-  text: string;
-  htmlFor?: string;
-  size?: 'sm' | 'md' | 'lg';
-  required?: boolean;
+export interface LabelProps extends HTMLAttributes<HTMLLabelElement> {
+  children: React.ReactNode;
+  textSize?: 'sm' | 'md' | 'lg' | 'xl';
+  textColor?: string;
 }
 
-export default function Label({ text, htmlFor, size = 'md', required = false }: LabelProps) {
-  const baseStyle = 'block text-gray-800 font-semibold';
-  const sizes = {
-    sm: 'text-xs',
-    md: 'text-sm',
-    lg: 'text-base',
-  };
-  const classes = clsx(baseStyle, sizes[size]);
+const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, children, textSize = 'md', textColor = undefined, ...props }, ref) => {
+    const classes = style({
+      textSize,
+    });
 
-  return (
-    <label htmlFor={htmlFor} className={classes}>
-      {required && (
-        <span aria-hidden="true" className="ml-1 text-red-500">
-          *{' '}
-        </span>
-      )}
-      {text}
-    </label>
-  );
-}
+    return (
+      <label className={clsx(classes, textColor, className)} {...props} ref={ref}>
+        {children}
+      </label>
+    );
+  }
+);
+
+export default Label;

--- a/src/components/wrappers/wrappers/LinkButton/LinkButton.tsx
+++ b/src/components/wrappers/wrappers/LinkButton/LinkButton.tsx
@@ -1,4 +1,5 @@
 import SVGIcon from '@/components/Icons/SVGIcon';
+import Label from '@/components/basics/Label/Label';
 import { getSafeUrl } from '@/hooks/util/getSafeUrl';
 import Link from 'next/link';
 
@@ -8,7 +9,7 @@ interface LinkButtonProps extends ButtonProps {
   href: string;
 }
 
-const LinkButton = ({ href, icon, size, label }: LinkButtonProps) => {
+const LinkButton = ({ href, icon, size, label, ...props }: LinkButtonProps) => {
   if (!icon && !label)
     console.error('LinkButton: Either icon or label should be provided for accessibility');
 
@@ -17,10 +18,12 @@ const LinkButton = ({ href, icon, size, label }: LinkButtonProps) => {
   const linkProps = isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {};
 
   return (
-    <Button asChild size={size}>
+    <Button asChild size={size} {...props}>
       <Link href={safeUrl} {...linkProps} className="flex items-center gap-1">
         {icon && <SVGIcon icon={icon} size={size} />}
-        <span className={icon ? 'pr-1' : ''}>{label}</span>
+        <Label textSize={size} className={icon ? 'pr-1' : ''}>
+          {label}
+        </Label>
       </Link>
     </Button>
   );

--- a/src/stories/Label.stories.tsx
+++ b/src/stories/Label.stories.tsx
@@ -1,34 +1,24 @@
-import Label from '@/components/basics/Label/Label';
+import Label, { LabelProps } from '@/components/basics/Label/Label';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof Label> = {
+const meta = {
   title: 'Components/Basics/Label',
   component: Label,
   tags: ['autodocs'],
   argTypes: {
-    text: {
-      control: 'text',
-    },
-    htmlFor: {
-      control: 'text',
-    },
-    size: {
-      control: 'select',
-    },
-    required: {
-      control: 'boolean',
-    },
+    textSize: { control: { type: 'inline-radio' } },
+    textColor: { control: 'text' },
+    children: { control: 'text' },
   },
-};
+} satisfies Meta<LabelProps>;
 
 export default meta;
-type Story = StoryObj<typeof Label>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    text: 'Label',
-    htmlFor: 'input-id',
-    size: 'md',
-    required: false,
+    textSize: 'md',
+    textColor: 'text-black',
+    children: '🔍 검색 라벨',
   },
 };


### PR DESCRIPTION
## 관련 이슈

- close #226

## PR 설명
- `Label` 컴포넌트 구현
- `Button`, `LinkButton`에 `Label` 컴포넌트 사용

`props` | `type` | 설명
`children` | `React.ReactNode` | 라벨로 띄울 내용
`textSize?` | `'sm' | 'md' | 'lg' | 'xl'` | default: `md`
`textColor?` | `string` | className에 바로 적용하여 색상 적용