### PR TITLE
Accordian 컴포넌트 구현

### DIFF
--- a/src/components/basics/Accordion/Accordion.tsx
+++ b/src/components/basics/Accordion/Accordion.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React, { HTMLAttributes, forwardRef, useState } from 'react';
+
+import AccordionButton from './AccordionButton/AccordionButton';
+
+interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+  openTitle: string;
+  closeTitle: string;
+}
+
+const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
+  ({ openTitle, closeTitle, children, ...props }, ref) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <div className="flex flex-col gap-2" ref={ref} {...props}>
+        {isOpen && <div className="font-body-md">{children}</div>}
+        <AccordionButton
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+          openTitle={openTitle}
+          closeTitle={closeTitle}
+        />
+      </div>
+    );
+  }
+);
+
+Accordion.displayName = 'Accordion';
+export default Accordion;

--- a/src/components/basics/Accordion/AccordionButton/AccordionButton.style.ts
+++ b/src/components/basics/Accordion/AccordionButton/AccordionButton.style.ts
@@ -1,0 +1,5 @@
+import { tv } from 'tailwind-variants';
+
+export const style = tv({
+  base: 'text-accordion font-detail flex w-fit items-end gap-1 transition-colors hover:cursor-pointer',
+});

--- a/src/components/basics/Accordion/AccordionButton/AccordionButton.tsx
+++ b/src/components/basics/Accordion/AccordionButton/AccordionButton.tsx
@@ -1,0 +1,27 @@
+import SVGIcon from '@/components/Icons/SVGIcon';
+
+import { style } from './AccordionButton.style';
+
+interface AccordionButtonProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  openTitle: string;
+  closeTitle: string;
+}
+
+const AccordionButton = ({ isOpen, setIsOpen, openTitle, closeTitle }: AccordionButtonProps) => {
+  return (
+    <button
+      type="button"
+      className={style()}
+      onClick={() => setIsOpen(prev => !prev)}
+      aria-expanded={isOpen}
+    >
+      <span>{isOpen ? openTitle : closeTitle}</span>
+      <SVGIcon icon={isOpen ? 'IC_ArrowdropUp' : 'IC_ArrowdropDown'} size="md" aria-hidden="true" />
+    </button>
+  );
+};
+
+AccordionButton.displayName = 'AccordionButton';
+export default AccordionButton;

--- a/src/stories/Accordian.stories.tsx
+++ b/src/stories/Accordian.stories.tsx
@@ -1,0 +1,24 @@
+import Accordion from '@/components/basics/Accordion/Accordion';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Basics/Accordion',
+  component: Accordion,
+  tags: ['autodocs'],
+  argTypes: {
+    closeTitle: { control: 'text' },
+    openTitle: { control: 'text' },
+    children: { control: 'text' },
+  },
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    closeTitle: '자세히',
+    openTitle: '간략히',
+    children: 'This is the content of the accordion.',
+  },
+};

--- a/src/styles/custom/colorTokens.css
+++ b/src/styles/custom/colorTokens.css
@@ -23,6 +23,10 @@
   /* accent */
   .text-accent-default{ @apply text-blue400; }
   
+  /* ========== accordion ========== */
+  .text-accordion { @apply text-gray400; }
+  .text-accordion:hover { @apply hover:text-gray500; }
+  .text-accordion:focus { @apply focus:text-gray500; }
   
   /* ========== ANCHOR ========== */
   .text-anchor { @apply text-gray400; }


### PR DESCRIPTION
## 관련 이슈

- close #141

## PR 설명
- `Accordian.tsx`
    - 링크 상세 패널에서 사용하는 `Accordian` 컴포넌트 구현 (요약 더보기에서 사용)
    - 추가적으로 사용되는 부분이 없어 요약 더보기에 맞추어 제작
    - `openTitle`, `closeTitle`을 props로 받음 (각각 열려있을 때, 닫혀있을 때 토글 제목을 표시)
- `colorTokens.css`
    - `accordian` 관련 css 토큰 추가