### PR TITLE
Badge 컴포넌트 구현

### DIFF
--- a/src/components/basics/Badge/Badge.style.ts
+++ b/src/components/basics/Badge/Badge.style.ts
@@ -1,0 +1,19 @@
+import { tv } from 'tailwind-variants';
+
+export const style = tv({
+  base: 'font-detail inline-flex items-center gap-1 rounded-full px-3 py-1.5',
+  variants: {
+    variant: {
+      primary: 'bg-blue400 text-white',
+      neutral: 'bg-gray200 text-gray900',
+    },
+    withIcon: {
+      true: 'pr-3 pl-2',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    variant: 'primary',
+    withIcon: true,
+  },
+});

--- a/src/components/basics/Badge/Badge.tsx
+++ b/src/components/basics/Badge/Badge.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import SVGIcon from '@/components/Icons/SVGIcon';
+import type { IconMapTypes } from '@/components/Icons/icons';
+import clsx from 'clsx';
+import React from 'react';
+
+import { style } from './Badge.style';
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  label: React.ReactNode;
+  icon?: IconMapTypes | null;
+  variant?: 'primary' | 'neutral';
+}
+
+export default function Badge({
+  label,
+  icon,
+  variant = 'primary',
+  className,
+  ...rest
+}: BadgeProps) {
+  const hasIcon = Boolean(icon);
+  const classes = style({ variant, withIcon: hasIcon });
+
+  return (
+    <span className={clsx(classes, className)} role="status" aria-live="polite" {...rest}>
+      {hasIcon && <SVGIcon icon={icon as IconMapTypes} size="sm" aria-hidden="true" />}
+      <span className="whitespace-nowrap">{label}</span>
+    </span>
+  );
+}

--- a/src/stories/Badge.stories.tsx
+++ b/src/stories/Badge.stories.tsx
@@ -1,0 +1,29 @@
+import Badge from '@/components/basics/Badge/Badge';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Basics/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  args: {
+    label: 'Badge Label',
+    icon: 'IC_SumGenerate',
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  args: {
+    label: 'Badge Label',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    label: 'Badge Label',
+    icon: 'IC_SumGenerate',
+  },
+};


### PR DESCRIPTION
## 관련 이슈

- close #88

## PR 설명
#### 개요

- 높이: 28px
- 아이콘 + 텍스트 조합
- 색상: `primary` (파란색), `neutral` (회색)

#### Props

| 이름 | 타입 | 기본값 | 설명 |
|------|------|--------|------|
| `label` | ReactNode | 필수 | 배지 텍스트 |
| `icon` | IconMapTypes \| null | `'IC_SumGenerate'` | 왼쪽 아이콘 |
| `variant` | 'primary' \| 'neutral' | 'primary' | 색상 테마 |
| `className` | string | - | 추가 클래스 |

#### 추가 파일

- `Badge.tsx` — 메인 컴포넌트
- `Badge.style.ts` — tailwind-variants 스타일
- `Badge.stories.tsx` — Storybook 스토리
