### PR TITLE
Refactor: AddLinkModal UI 수정 (#236)

### DIFF
--- a/src/components/basics/TextArea/TextArea.style.ts
+++ b/src/components/basics/TextArea/TextArea.style.ts
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 export const wholeBoxStyle = tv({
-  base: 'relative inline-block border bg-white pt-2 pr-1 pb-6 pl-3',
+  base: 'relative inline-block w-full border bg-white pt-2 pr-1 pb-6 pl-3',
   variants: {
     variant: {
       default: 'border-gray100 focus-within:border-gray300',
@@ -15,7 +15,7 @@ export const wholeBoxStyle = tv({
 });
 
 export const textAreaStyle = tv({
-  base: 'placeholder:text-gray500 text-gray900 custom-scrollbar resize-none pr-3 focus:outline-none',
+  base: 'placeholder:text-gray500 text-gray900 custom-scrollbar w-full resize-none pr-3 focus:outline-none',
   variants: {
     textSize: {
       sm: 'font-body-sm',

--- a/src/components/basics/TextArea/TextArea.tsx
+++ b/src/components/basics/TextArea/TextArea.tsx
@@ -14,7 +14,6 @@ export interface TextAreaProps extends Omit<
   className?: string;
   variant?: 'default';
   textSize?: 'sm' | 'md' | 'lg';
-  widthPx: number; // px
   heightLines: number; // 줄 수
   maxHeightLines?: number; // 줄 수
   radius?: 'md' | 'lg' | 'full';
@@ -33,7 +32,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
     value,
     variant = 'default',
     textSize = 'md',
-    widthPx,
     heightLines,
     maxHeightLines,
     radius = 'md',
@@ -82,7 +80,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
         placeholder={placeholder}
         aria-label={placeholder}
         maxLength={maxLength && maxLength > 0 ? maxLength : undefined}
-        style={{ width: `${widthPx}px`, minHeight: `${minHeight}px` }}
+        style={{ minHeight: `${minHeight}px` }}
         onChange={onChange}
         onKeyDown={handleKeyDown}
         {...rest}

--- a/src/components/layout/SideNavigation/components/AddLinkModal/AddLinkModal.tsx
+++ b/src/components/layout/SideNavigation/components/AddLinkModal/AddLinkModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Button from '@/components/basics/Button/Button';
-import Divider from '@/components/basics/Divider/Divider';
 import Input from '@/components/basics/Input/Input';
 import Label from '@/components/basics/Label/Label';
 import Modal from '@/components/basics/Modal/Modal';
 import TextArea from '@/components/basics/TextArea/TextArea';
+import { useModalStore } from '@/stores/modalStore';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Image from 'next/image';
 import { useState } from 'react';
@@ -20,7 +20,9 @@ const addLinkSchema = z.object({
 type AddLinkForm = z.infer<typeof addLinkSchema>;
 
 const AddLinkModal = () => {
-  const [imageUrl] = useState('/file.svg?react');
+  const { close } = useModalStore();
+  const [imageUrl] = useState('/file.svg');
+
   const {
     control,
     handleSubmit,
@@ -33,10 +35,11 @@ const AddLinkModal = () => {
 
   const onSubmit = (data: AddLinkForm) => {
     console.log(data);
+    close();
   };
 
   return (
-    <Modal type="ADD_LINK">
+    <Modal type="ADD_LINK" className="m-10 min-w-150">
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <Label htmlFor="url-input">URL</Label>
@@ -54,15 +57,16 @@ const AddLinkModal = () => {
           />
           {errors.url && <span className="text-red500 text-xs">{errors.url.message}</span>}
         </div>
-        <Divider width={2} />
         <div className="flex flex-col gap-1">
-          <span>Contents</span>
-          <div className="flex items-center gap-2">
-            <div className="border-gray100 relative h-28 w-42 rounded-2xl border bg-white">
-              <Image src={imageUrl} alt="link thumbnail" fill />
+          <div className="flex gap-2">
+            <div className="flex flex-1 flex-col">
+              <Label>썸네일</Label>
+              <div className="relative h-23 rounded-lg bg-white">
+                <Image src={imageUrl} alt="link thumbnail" fill />
+              </div>
             </div>
-            <div className="flex flex-col">
-              <Label htmlFor="title-input">Title</Label>
+            <div className="flex flex-3 flex-col">
+              <Label htmlFor="title-input">제목</Label>
               <Controller
                 name="title"
                 control={control}
@@ -71,7 +75,6 @@ const AddLinkModal = () => {
                     {...field}
                     placeholder="제목을 입력해주세요"
                     id="title-input"
-                    widthPx={400}
                     radius="lg"
                     heightLines={2}
                     maxHeightLines={2}
@@ -83,9 +86,8 @@ const AddLinkModal = () => {
             </div>
           </div>
         </div>
-        <Divider width={2} />
-        <div className="flex flex-col">
-          <Label htmlFor="memo-input">Memo</Label>
+        <div className="flex w-full flex-col">
+          <Label htmlFor="memo-input">메모</Label>
           <Controller
             name="memo"
             control={control}
@@ -96,7 +98,6 @@ const AddLinkModal = () => {
                 id="memo-input"
                 placeholder="메모를 입력해주세요"
                 radius="lg"
-                widthPx={576}
                 heightLines={3}
                 maxHeightLines={3}
                 maxLength={600}

--- a/src/components/wrappers/MemoTextArea/MemoTextArea.tsx
+++ b/src/components/wrappers/MemoTextArea/MemoTextArea.tsx
@@ -10,7 +10,6 @@ const MemoTextArea = ({ value, onChange }: MemoTextAreaProps) => {
   return (
     <TextArea
       value={value}
-      widthPx={480}
       heightLines={2}
       maxHeightLines={6}
       maxLength={200}

--- a/src/components/wrappers/QueryBox/QueryBox.tsx
+++ b/src/components/wrappers/QueryBox/QueryBox.tsx
@@ -38,9 +38,9 @@ const QueryBox = ({ onSubmit }: QueryBoxProps) => {
         placeholder="Linkiving에게 물어보세요."
         radius="lg"
         value={value}
-        widthPx={720}
         onChange={e => setValue(e.target.value)}
         onSubmit={onSubmit}
+        className="w-280"
       />
       <SendButton disabled={!value || isSending} onClick={handleSubmit} />
       {error && <div className="mt-1 text-sm text-red-500">{error}</div>}

--- a/src/components/wrappers/TitleTextArea/TitleTextArea.tsx
+++ b/src/components/wrappers/TitleTextArea/TitleTextArea.tsx
@@ -13,7 +13,6 @@ const TitleTextArea = ({ value, onChange }: TitleTextAreaProps) => {
   return (
     <TextArea
       value={value}
-      widthPx={480}
       heightLines={2}
       maxHeightLines={3}
       maxLength={100}

--- a/src/stories/TextArea.stories.tsx
+++ b/src/stories/TextArea.stories.tsx
@@ -12,7 +12,6 @@ const meta = {
   },
   argTypes: {
     placeholder: { control: 'text' },
-    widthPx: { control: 'number', description: '가로 길이(px)' },
     heightLines: { control: 'number', description: '초기 줄 수' },
     maxHeightLines: { control: 'number', description: '최대 줄 수' },
     maxLength: {
@@ -45,7 +44,6 @@ export const Default: Story = {
   render: args => <InteractiveTextArea {...args} />,
   args: {
     placeholder: '무엇이든 물어보세요',
-    widthPx: 250,
     heightLines: 3,
     maxHeightLines: 6,
     maxLength: 200,


### PR DESCRIPTION
## 관련 이슈

- close #236

## PR 설명
- 링크 추가 모달 UI 수정
- `TextArea`의 `width`를 고정된 값이 아닌 부모 넓이에 따라 유연하게 처리하기 위해 props 삭제