### PR TITLE
LinkCard UI 수정

### DIFF
--- a/src/components/basics/Anchor/Anchor.tsx
+++ b/src/components/basics/Anchor/Anchor.tsx
@@ -61,7 +61,7 @@ const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function Anchor(
       {iconVisible && (
         <SVGIcon icon="IC_LinkOpen" size={sizeMap[size]} aria-hidden="true" className="mb-px" />
       )}
-      {children}
+      <span className="truncate">{children}</span>
     </a>
   );
 });

--- a/src/components/basics/Badge/Badge.style.ts
+++ b/src/components/basics/Badge/Badge.style.ts
@@ -6,6 +6,7 @@ export const style = tv({
     variant: {
       primary: 'bg-blue400 text-white',
       neutral: 'bg-gray200 text-gray900',
+      warning: 'bg-warning-dark text-gray800',
     },
     withIcon: {
       true: 'pr-3 pl-2',

--- a/src/components/basics/Badge/Badge.tsx
+++ b/src/components/basics/Badge/Badge.tsx
@@ -10,7 +10,7 @@ import { style } from './Badge.style';
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   label: React.ReactNode;
   icon?: IconMapTypes | null;
-  variant?: 'primary' | 'neutral';
+  variant?: 'primary' | 'neutral' | 'warning';
 }
 
 export default function Badge({

--- a/src/components/basics/LinkCard/LinkCard.style.ts
+++ b/src/components/basics/LinkCard/LinkCard.style.ts
@@ -1,5 +1,0 @@
-import { tv } from 'tailwind-variants';
-
-export const cardStyle = tv({
-  base: `border-gray100 bg-gray50 hover:border-blue100 hover:bg-blue50 focus:border-blue200 focus:bg-blue50 flex h-55 w-47 flex-col overflow-hidden rounded-2xl border transition-colors hover:cursor-pointer`,
-});

--- a/src/components/basics/LinkCard/LinkCard.tsx
+++ b/src/components/basics/LinkCard/LinkCard.tsx
@@ -6,19 +6,19 @@ import Image from 'next/image';
 import React from 'react';
 
 import Anchor from '../Anchor/Anchor';
-import { cardStyle } from './LinkCard.style';
-import AddSummaryButton from './components/AddSummaryButton';
+import Badge from '../Badge/Badge';
+
+const SUMMARY_FAIL_TEXT = '요약 생성에 실패했습니다. 상세 패널에서 다시 시도해보세요.';
 
 interface LinkCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'> {
   imageUrl: string;
-  isHaveSummary?: boolean;
   link: string;
   summary: string;
   title: string;
   onClick?: () => void;
 }
 const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCard(
-  { imageUrl, isHaveSummary = false, link, summary, title, onClick, ...rest },
+  { imageUrl, link, summary, title, onClick, ...rest },
   ref
 ) {
   const handleKeyDown = useInteractiveKeyBlock({ onClick });
@@ -27,24 +27,32 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
   return (
     <div
       ref={ref}
-      className={cardStyle()}
+      className="border-gray200 hover:bg-gray50 active:bg-blue50 focus:border-blue500 relative flex h-58 w-47 cursor-pointer flex-col overflow-hidden rounded-2xl border transition-colors"
       tabIndex={0}
       onClick={onClick}
       onKeyDown={handleKeyDown}
       {...rest}
     >
-      <div className="bg-gray900 flex h-22 w-full shrink-0">
+      {!summary && (
+        <Badge
+          label="요약 실패"
+          icon="IC_Warning"
+          variant="warning"
+          className="absolute top-2 left-2 z-10"
+        />
+      )}
+
+      <div className="bg-gray900 relative h-22 w-full shrink-0">
         <Image
           src={imageUrl ? imageUrl : '/images/default_linkcard_image.png'}
           alt={title}
-          width={240}
-          height={120}
-          className="object-cover"
+          fill
+          className="border-gray200 border-b object-cover"
         />
       </div>
-      <div className="flex h-full flex-col justify-between p-3">
+      <div className="flex flex-1 flex-col justify-between p-3">
         <div className="flex flex-col gap-1">
-          <span className="text-gray900 truncate text-sm font-semibold">{title}</span>
+          <span className="truncate text-sm font-semibold">{title}</span>
           <div className="flex items-center gap-1">
             <Anchor
               href={safeHref}
@@ -55,13 +63,11 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
             </Anchor>
           </div>
         </div>
-        {isHaveSummary ? (
-          <span className="text-etc-linkcard-summary line-clamp-2 text-xs font-normal">
-            {summary}
-          </span>
+        {!!summary ? (
+          <span className="text-etc-linkcard-summary font-body-sm line-clamp-2">{summary}</span>
         ) : (
-          <div className="flex justify-end">
-            <AddSummaryButton />
+          <div className="font-body-sm text-etc-linkcard-summary flex justify-end">
+            <span>{SUMMARY_FAIL_TEXT}</span>
           </div>
         )}
       </div>

--- a/src/components/basics/Toast/Toast.style.ts
+++ b/src/components/basics/Toast/Toast.style.ts
@@ -15,32 +15,32 @@ export const style = tv({
     },
   },
   compoundVariants: [
-    { variant: 'success', theme: 'light', class: 'bg-feedback-success-light text-default' },
+    { variant: 'success', theme: 'light', class: 'bg-success-light text-default' },
     {
       variant: 'success',
       theme: 'dark',
-      class: 'bg-feedback-success-dark [color:var(--label-primary-default)]',
+      class: 'bg-success-dark [color:var(--label-primary-default)]',
     },
 
-    { variant: 'error', theme: 'light', class: 'bg-feedback-error-light text-default' },
+    { variant: 'error', theme: 'light', class: 'bg-error-light text-default' },
     {
       variant: 'error',
       theme: 'dark',
-      class: 'bg-feedback-error-dark [color:var(--label-primary-default)]',
+      class: 'bg-error-dark [color:var(--label-primary-default)]',
     },
 
-    { variant: 'info', theme: 'light', class: 'bg-feedback-inform-light text-default' },
+    { variant: 'info', theme: 'light', class: 'bg-inform-light text-default' },
     {
       variant: 'info',
       theme: 'dark',
-      class: 'bg-feedback-inform-dark [color:var(--label-primary-default)]',
+      class: 'bg-inform-dark [color:var(--label-primary-default)]',
     },
 
-    { variant: 'warning', theme: 'light', class: 'bg-feedback-warning-light text-default' },
+    { variant: 'warning', theme: 'light', class: 'bg-warning-light text-default' },
     {
       variant: 'warning',
       theme: 'dark',
-      class: 'bg-feedback-warning-dark [color:var(--text-default)]',
+      class: 'bg-warning-dark [color:var(--text-default)]',
     },
   ],
   defaultVariants: {

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
   },
   argTypes: {
     imageUrl: { control: 'text' },
-    isHaveSummary: { control: 'boolean' },
     title: { control: 'text' },
     summary: { control: 'text' },
     link: { control: 'text' },
@@ -24,7 +23,6 @@ type Story = StoryObj<typeof LinkCard>;
 export const Default: Story = {
   args: {
     imageUrl: '',
-    isHaveSummary: false,
     link: 'https://naver.com',
     summary: 'This is a sample bookmark card with a placeholder image.',
     title: 'Link Title',

--- a/src/styles/custom/colorTokens.css
+++ b/src/styles/custom/colorTokens.css
@@ -8,17 +8,17 @@
   .text-etc-linkcard-summary { @apply text-gray700; }
   
   /* bg-feedback */
-  .bg-feedback-success-light { @apply bg-green50; }
-  .bg-feedback-success-dark { @apply bg-green500; }
+  .bg-success-light { @apply bg-green50; }
+  .bg-success-dark { @apply bg-green500; }
   
-  .bg-feedback-error-light { @apply bg-red50; }
-  .bg-feedback-error-dark { @apply bg-red500; }
+  .bg-error-light { @apply bg-red50; }
+  .bg-error-dark { @apply bg-red500; }
   
   .bg-feedback-inform-light { @apply bg-skyblue50; }
-  .bg-feedback-inform-dark { @apply bg-skyblue500; }
+  .bg-inform-dark { @apply bg-skyblue500; }
   
-  .bg-feedback-warning-light { @apply bg-yellow50; }
-  .bg-feedback-warning-dark { @apply bg-yellow500; }
+  .bg-warning-light { @apply bg-yellow50; }
+  .bg-warning-dark { @apply bg-yellow500; }
   
   /* accent */
   .text-accent-default{ @apply text-blue400; }


### PR DESCRIPTION
## 관련 이슈

- close #259 

## PR 설명
- 피그마에서 수정된 LinkCard UI 적용
- 경고 뱃지 추가
- LinkCard 경고 뱃지에 warning 색상이 확인되어 관련 코드 수정
    - `colorTokens.css` - 색상토큰명에서 `feedback` 삭제
    - `Badge.tsx` - variant에 `'warning'` 추가