### PR TITLE
Skeleton 컴포넌트 스토리북 미기재 해결

### DIFF
--- a/src/components/basics/Skeleton/Skeleton.style.ts
+++ b/src/components/basics/Skeleton/Skeleton.style.ts
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 export const styles = tv({
-  base: 'relative isolate overflow-hidden select-none',
+  base: 'bg-gray100 relative isolate overflow-hidden text-transparent select-none',
   variants: {
     radius: {
       none: 'rounded-none',


### PR DESCRIPTION
## 관련 이슈

- close #270

## PR 설명

- 스켈레톤이 스토리북에 안뜨는 현상을 해결했습니다.
- 원인은 기본 배경이 없던 이유였습니다. text-transparent를 style에 추가하여 해결했습니다.