### PR TITLE
링크 관련 api 함수 구현

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -1,0 +1,199 @@
+import type { CreateLinkPayload, Link, PageResponse, UpdateLinkPayload } from '@/types/link';
+
+const LINKS_ENDPOINT = '/api/links';
+
+export type LinkListParams = {
+  page?: number;
+  size?: number;
+  sort?: string[] | string;
+};
+
+function buildQuery(params?: LinkListParams) {
+  if (!params) return '';
+  const usp = new URLSearchParams();
+  if (params.page !== undefined) usp.set('page', String(params.page));
+  if (params.size !== undefined) usp.set('size', String(params.size));
+  if (params.sort) {
+    const sorts = Array.isArray(params.sort) ? params.sort : [params.sort];
+    sorts.forEach(s => usp.append('sort', s));
+  }
+  const qs = usp.toString();
+  return qs ? `?${qs}` : '';
+}
+
+export const fetchLinks = async (params?: LinkListParams): Promise<PageResponse<Link>> => {
+  const res = await fetch(`${LINKS_ENDPOINT}${buildQuery(params)}`, { cache: 'no-store' });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message = (errorBody as { error?: string } | null)?.error ?? 'Failed to fetch links';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as {
+    data?: PageResponse<Link>;
+  };
+
+  if (!body?.data) {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};
+
+export const createLink = async (payload: CreateLinkPayload): Promise<Link> => {
+  const res = await fetch(LINKS_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message = (errorBody as { error?: string } | null)?.error ?? 'Failed to create link';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as { data?: Link };
+  if (!body?.data) {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};
+
+export const fetchLink = async (id: number): Promise<Link> => {
+  const res = await fetch(`${LINKS_ENDPOINT}/${id}`, { cache: 'no-store' });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message = (errorBody as { error?: string } | null)?.error ?? 'Failed to fetch link';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as { data?: Link };
+  if (!body?.data) {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};
+
+export const updateLink = async (id: number, payload: UpdateLinkPayload): Promise<Link> => {
+  const res = await fetch(`${LINKS_ENDPOINT}/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message = (errorBody as { error?: string } | null)?.error ?? 'Failed to update link';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as { data?: Link };
+  if (!body?.data) {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};
+
+export const updateLinkTitle = async (id: number, title: string): Promise<Link> => {
+  const res = await fetch(`${LINKS_ENDPOINT}/${id}/title`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message =
+      (errorBody as { error?: string } | null)?.error ?? 'Failed to update link title';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as { data?: Link };
+  if (!body?.data) {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};
+
+export const updateLinkMemo = async (id: number, memo: string): Promise<Link> => {
+  const res = await fetch(`${LINKS_ENDPOINT}/${id}/memo`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ memo }),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message = (errorBody as { error?: string } | null)?.error ?? 'Failed to update link memo';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as { data?: Link };
+  if (!body?.data) {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};
+
+export const deleteLink = async (
+  id: number
+): Promise<{
+  success: boolean;
+  status: string;
+  message: string;
+  data: string;
+  timestamp: string;
+}> => {
+  const res = await fetch(`${LINKS_ENDPOINT}/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message = (errorBody as { error?: string } | null)?.error ?? 'Failed to delete link';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as {
+    success: boolean;
+    status: string;
+    message: string;
+    data: string;
+    timestamp: string;
+  };
+
+  if (!body || typeof body.success !== 'boolean' || !body.status || !body.message) {
+    throw new Error('Invalid response');
+  }
+
+  return body;
+};
+
+export const checkDuplicateLink = async (url: string): Promise<boolean> => {
+  const usp = new URLSearchParams({ url });
+  const res = await fetch(`${LINKS_ENDPOINT}/duplicate?${usp.toString()}`, {
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => null);
+    const message =
+      (errorBody as { error?: string } | null)?.error ?? 'Failed to check duplicate link';
+    throw new Error(message);
+  }
+
+  const body = (await res.json()) as { data?: boolean };
+  if (typeof body?.data !== 'boolean') {
+    throw new Error('Invalid response');
+  }
+
+  return body.data;
+};

--- a/src/app/(route)/link-api-demo/LinkApiDemo.tsx
+++ b/src/app/(route)/link-api-demo/LinkApiDemo.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import Button from '@/components/basics/Button/Button';
+import Input from '@/components/basics/Input/Input';
+import Label from '@/components/basics/Label/Label';
+import TextArea from '@/components/basics/TextArea/TextArea';
+import { useCheckDuplicateLink } from '@/hooks/useCheckDuplicateLink';
+import { useDeleteLink } from '@/hooks/useDeleteLink';
+import { useGetLinks } from '@/hooks/useGetLinks';
+import { usePostLinks } from '@/hooks/usePostLinks';
+import { useUpdateLinkMemo } from '@/hooks/useUpdateLinkMemo';
+import { useUpdateLinkTitle } from '@/hooks/useUpdateLinkTitle';
+import type { Link } from '@/types/link';
+import { useEffect, useMemo, useState } from 'react';
+
+const defaultCreate = {
+  url: '',
+  title: '',
+  memo: '',
+  imageUrl: '',
+  metadataJson: '',
+  tags: '',
+  isImportant: false,
+};
+
+export default function LinkApiDemo() {
+  const [createForm, setCreateForm] = useState(defaultCreate);
+  const [duplicateUrl, setDuplicateUrl] = useState('');
+  const [duplicateQueryUrl, setDuplicateQueryUrl] = useState<string | undefined>();
+  const { data, isLoading, isError, refetch } = useGetLinks({ page: 0, size: 20 });
+  const createMut = usePostLinks();
+  const deleteMut = useDeleteLink();
+  const updateTitleMut = useUpdateLinkTitle();
+  const updateMemoMut = useUpdateLinkMemo();
+  const {
+    data: isDuplicate,
+    isFetching: isCheckingDuplicate,
+    error: duplicateError,
+  } = useCheckDuplicateLink(duplicateQueryUrl);
+
+  useEffect(() => {
+    if (createMut.isSuccess) {
+      setCreateForm(defaultCreate);
+    }
+  }, [createMut.isSuccess]);
+
+  const links = useMemo(() => data?.content ?? [], [data]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createMut.mutateAsync(createForm);
+    } catch {
+      // 에러는 createMut.isError를 통해 UI에서 표시
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteMut.mutateAsync(id);
+    } catch {
+      // 에러는 LinkCardRow 혹은 deleteMut.isError를 통해 표시
+    }
+  };
+
+  const handleUpdateTitle = async (id: number, title: string) => {
+    await updateTitleMut.mutateAsync({ id, title });
+  };
+
+  const handleUpdateMemo = async (id: number, memo: string) => {
+    await updateMemoMut.mutateAsync({ id, memo });
+  };
+
+  const handleCheckDuplicate = (e: React.FormEvent) => {
+    e.preventDefault();
+    setDuplicateQueryUrl(duplicateUrl);
+  };
+
+  const renderStatus = () => {
+    if (isLoading) return <span className="text-gray600">불러오는 중...</span>;
+    if (isError) return <span className="text-red500">목록을 불러오지 못했습니다.</span>;
+    return null;
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Link API 데모</h1>
+        <p className="text-gray600">
+          목록 조회, 생성, 제목/메모 수정, 삭제, 중복 확인을 한 눈에 확인할 수 있습니다.
+        </p>
+      </header>
+
+      {/* 생성 */}
+      <section className="border-gray200 rounded-xl border bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold">새 링크 생성</h2>
+        <form className="mt-4 grid grid-cols-2 gap-4" onSubmit={handleCreate}>
+          <div className="col-span-2 flex flex-col gap-2">
+            <Label htmlFor="create-url">URL</Label>
+            <Input
+              id="create-url"
+              value={createForm.url}
+              placeholder="https://example.com"
+              onChange={e => setCreateForm(prev => ({ ...prev, url: e.target.value }))}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="create-title">제목</Label>
+            <Input
+              id="create-title"
+              value={createForm.title}
+              placeholder="링크 제목"
+              onChange={e => setCreateForm(prev => ({ ...prev, title: e.target.value }))}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="create-tags">태그 (콤마 구분)</Label>
+            <Input
+              id="create-tags"
+              value={createForm.tags}
+              placeholder="예) 개발,자료,참고"
+              onChange={e => setCreateForm(prev => ({ ...prev, tags: e.target.value }))}
+            />
+          </div>
+          <div className="col-span-2 flex flex-col gap-2">
+            <Label htmlFor="create-memo">메모</Label>
+            <TextArea
+              id="create-memo"
+              value={createForm.memo}
+              onChange={e => setCreateForm(prev => ({ ...prev, memo: e.target.value }))}
+              placeholder="나중에 읽어볼 것"
+              heightLines={2}
+              maxHeightLines={4}
+            />
+          </div>
+          <div className="flex items-end gap-2">
+            <Button
+              type="submit"
+              label={createMut.isPending ? '생성 중...' : '생성하기'}
+              disabled={!createForm.url || !createForm.title || createMut.isPending}
+            />
+            {createMut.isError && (
+              <span className="text-red500 text-sm">생성 실패: {createMut.error?.message}</span>
+            )}
+            {createMut.isSuccess && (
+              <span className="text-green600 text-sm">생성 완료! 목록을 새로고침했습니다.</span>
+            )}
+          </div>
+        </form>
+      </section>
+
+      {/* 중복 체크 */}
+      <section className="border-gray200 rounded-xl border bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold">URL 중복 체크</h2>
+        <form className="mt-3 flex flex-wrap items-center gap-3" onSubmit={handleCheckDuplicate}>
+          <Input
+            className="min-w-80 flex-1"
+            value={duplicateUrl}
+            placeholder="중복을 확인할 URL 입력"
+            onChange={e => setDuplicateUrl(e.target.value)}
+          />
+          <Button type="submit" label={isCheckingDuplicate ? '확인 중...' : '중복 확인'} />
+          {duplicateError && <span className="text-red500 text-sm">{duplicateError.message}</span>}
+          {duplicateQueryUrl && !isCheckingDuplicate && !duplicateError && (
+            <span
+              className={`text-sm ${isDuplicate ? 'text-red600' : 'text-green600'}`}
+              data-testid="duplicate-result"
+            >
+              {isDuplicate ? '이미 존재하는 URL입니다.' : '사용 가능한 URL입니다.'}
+            </span>
+          )}
+        </form>
+      </section>
+
+      {/* 목록 */}
+      <section className="border-gray200 rounded-xl border bg-white p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">링크 목록</h2>
+            <p className="text-gray600 text-sm">총 {data?.totalElements ?? 0}개</p>
+          </div>
+          <Button variant="secondary" label="새로고침" onClick={() => refetch()} />
+        </div>
+        {renderStatus()}
+        {!isLoading && links.length === 0 && (
+          <p className="text-gray600">표시할 링크가 없습니다. 새 링크를 생성해 보세요.</p>
+        )}
+        <div className="mt-2 grid gap-3 md:grid-cols-2">
+          {links.map(link => (
+            <LinkCardRow
+              key={link.id}
+              link={link}
+              onDelete={handleDelete}
+              onUpdateTitle={handleUpdateTitle}
+              onUpdateMemo={handleUpdateMemo}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LinkCardRow({
+  link,
+  onDelete,
+  onUpdateTitle,
+  onUpdateMemo,
+}: {
+  link: Link;
+  onDelete: (id: number) => Promise<void>;
+  onUpdateTitle: (id: number, title: string) => Promise<void>;
+  onUpdateMemo: (id: number, memo: string) => Promise<void>;
+}) {
+  const [nextTitle, setNextTitle] = useState(link.title);
+  const [nextMemo, setNextMemo] = useState(link.memo ?? '');
+  const [saving, setSaving] = useState<'title' | 'memo' | 'delete' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setNextTitle(link.title);
+    setNextMemo(link.memo ?? '');
+  }, [link.title, link.memo]);
+
+  const handleTitleSave = async () => {
+    setSaving('title');
+    setError(null);
+    try {
+      await onUpdateTitle(link.id, nextTitle);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleMemoSave = async () => {
+    setSaving('memo');
+    setError(null);
+    try {
+      await onUpdateMemo(link.id, nextMemo);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    setSaving('delete');
+    setError(null);
+    try {
+      await onDelete(link.id);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <div className="border-gray200 flex flex-col gap-3 rounded-lg border p-3 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col">
+          <span className="text-gray500 text-sm">#{link.id}</span>
+          <a
+            href={link.url}
+            className="text-blue600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {link.url}
+          </a>
+          <span className="text-gray500 text-xs">
+            생성: {new Date(link.createdAt).toLocaleString()}
+          </span>
+        </div>
+        <Button
+          size="sm"
+          variant="tertiary_neutral"
+          label={saving === 'delete' ? '삭제 중...' : '삭제'}
+          onClick={handleDelete}
+          disabled={saving !== null}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={`title-${link.id}`}>제목</Label>
+        <div className="flex gap-2">
+          <Input
+            id={`title-${link.id}`}
+            value={nextTitle}
+            onChange={e => setNextTitle(e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            size="sm"
+            label={saving === 'title' ? '저장 중...' : '제목 수정'}
+            onClick={handleTitleSave}
+            disabled={saving !== null}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={`memo-${link.id}`}>메모</Label>
+        <TextArea
+          id={`memo-${link.id}`}
+          value={nextMemo}
+          onChange={e => setNextMemo(e.target.value)}
+          heightLines={2}
+          maxHeightLines={4}
+        />
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="secondary"
+            label={saving === 'memo' ? '저장 중...' : '메모 수정'}
+            onClick={handleMemoSave}
+            disabled={saving !== null}
+          />
+        </div>
+      </div>
+
+      {link.tags && <p className="text-gray600 text-sm">태그: {link.tags}</p>}
+      {link.isImportant && <p className="text-amber600 text-sm">중요 표시됨</p>}
+      {error && <p className="text-red500 text-sm">오류: {error}</p>}
+    </div>
+  );
+}

--- a/src/app/(route)/link-api-demo/page.tsx
+++ b/src/app/(route)/link-api-demo/page.tsx
@@ -1,0 +1,9 @@
+import LinkApiDemo from './LinkApiDemo';
+
+export default function Page() {
+  return (
+    <main>
+      <LinkApiDemo />
+    </main>
+  );
+}

--- a/src/app/api/links/[id]/memo/route.ts
+++ b/src/app/api/links/[id]/memo/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+
+import { links } from '../../data';
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  if (Number.isNaN(id)) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'invalid id',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const idx = links.findIndex(item => item.id === id);
+  if (idx === -1 || links[idx].isDeleted) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      { success: false, status: '404 NOT_FOUND', message: 'not found', data: null, timestamp: now },
+      { status: 404 }
+    );
+  }
+
+  let body: { memo?: string | null };
+  try {
+    body = (await req.json()) as { memo?: string | null };
+  } catch {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'Invalid JSON body',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  if (body.memo === undefined || body.memo === null) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'memo is required',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const now = new Date().toISOString();
+  const updated = {
+    ...links[idx],
+    memo: body.memo,
+    updatedAt: now,
+  };
+  links[idx] = updated;
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '200 OK',
+      message: 'updated',
+      data: updated,
+      timestamp: now,
+    },
+    { status: 200 }
+  );
+}

--- a/src/app/api/links/[id]/route.ts
+++ b/src/app/api/links/[id]/route.ts
@@ -1,0 +1,154 @@
+import type { UpdateLinkPayload } from '@/types/link';
+import { NextResponse } from 'next/server';
+
+import { links } from '../data';
+
+export async function GET(_: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  if (Number.isNaN(id)) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'invalid id',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const link = links.find(item => item.id === id);
+  if (!link || link.isDeleted) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      { success: false, status: '404 NOT_FOUND', message: 'not found', data: null, timestamp: now },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '200 OK',
+      message: 'ok',
+      data: link,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  );
+}
+
+export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  if (Number.isNaN(id)) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'invalid id',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const idx = links.findIndex(item => item.id === id);
+  if (idx === -1 || links[idx].isDeleted) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      { success: false, status: '404 NOT_FOUND', message: 'not found', data: null, timestamp: now },
+      { status: 404 }
+    );
+  }
+
+  let body: UpdateLinkPayload;
+  try {
+    body = (await req.json()) as UpdateLinkPayload;
+  } catch {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'Invalid JSON body',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const target = links[idx];
+  const next = {
+    ...target,
+    ...Object.fromEntries(
+      Object.entries(body).filter(([, value]) => value !== null && value !== undefined)
+    ),
+    updatedAt: new Date().toISOString(),
+  };
+
+  links[idx] = next;
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '200 OK',
+      message: 'updated',
+      data: next,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  );
+}
+
+export async function DELETE(_: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  if (Number.isNaN(id)) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'invalid id',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const idx = links.findIndex(item => item.id === id);
+  if (idx === -1 || links[idx].isDeleted) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      { success: false, status: '404 NOT_FOUND', message: 'not found', data: null, timestamp: now },
+      { status: 404 }
+    );
+  }
+
+  const now = new Date().toISOString();
+  links[idx] = {
+    ...links[idx],
+    isDeleted: true,
+    deletedAt: now,
+    updatedAt: now,
+  };
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '200 OK',
+      message: 'deleted',
+      data: String(id),
+      timestamp: now,
+    },
+    { status: 200 }
+  );
+}

--- a/src/app/api/links/[id]/title/route.ts
+++ b/src/app/api/links/[id]/title/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+
+import { links } from '../../data';
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  if (Number.isNaN(id)) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'invalid id',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const idx = links.findIndex(item => item.id === id);
+  if (idx === -1 || links[idx].isDeleted) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      { success: false, status: '404 NOT_FOUND', message: 'not found', data: null, timestamp: now },
+      { status: 404 }
+    );
+  }
+
+  let body: { title?: string | null };
+  try {
+    body = (await req.json()) as { title?: string | null };
+  } catch {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'Invalid JSON body',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const normalizedTitle = (body.title ?? '').trim();
+  if (!normalizedTitle) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'title is required',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const now = new Date().toISOString();
+  const updated = {
+    ...links[idx],
+    title: normalizedTitle,
+    updatedAt: now,
+  };
+  links[idx] = updated;
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '200 OK',
+      message: 'updated',
+      data: updated,
+      timestamp: now,
+    },
+    { status: 200 }
+  );
+}

--- a/src/app/api/links/data.ts
+++ b/src/app/api/links/data.ts
@@ -1,0 +1,32 @@
+import type { Link } from '@/types/link';
+
+export const links: Link[] = [
+  {
+    id: 1,
+    url: 'https://nextjs.org/docs',
+    title: 'Next.js Documentation',
+    memo: 'Key features and routing docs.',
+    summary: 'Official Next.js documentation covering the App Router and core APIs.',
+    imageUrl: '/images/default_linkcard_image.png',
+    metadataJson: '{}',
+    tags: 'nextjs,guide',
+    isImportant: false,
+    isDeleted: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    url: 'https://tanstack.com/query/latest',
+    title: 'TanStack Query Guide',
+    memo: 'Useful for query patterns.',
+    summary: 'Overview of TanStack Query usage patterns and API surface.',
+    imageUrl: '/images/default_linkcard_image.png',
+    metadataJson: '{}',
+    tags: 'react-query,guide',
+    isImportant: true,
+    isDeleted: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];

--- a/src/app/api/links/duplicate/route.ts
+++ b/src/app/api/links/duplicate/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+import { links } from '../data';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const url = searchParams.get('url');
+
+  if (!url) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'url is required',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const isDuplicate = links.some(link => !link.isDeleted && link.url === url);
+  const timestamp = new Date().toISOString();
+
+  return NextResponse.json({
+    success: true,
+    status: '200 OK',
+    message: 'ok',
+    data: isDuplicate,
+    timestamp,
+  });
+}

--- a/src/app/api/links/route.ts
+++ b/src/app/api/links/route.ts
@@ -1,0 +1,173 @@
+import type { CreateLinkPayload, Link, PageResponse, PageSort, Pageable } from '@/types/link';
+import { NextResponse } from 'next/server';
+
+import { links } from './data';
+
+function parseSort(sortParams: string[]): { field: keyof Link; direction: 'asc' | 'desc' } | null {
+  if (!sortParams.length) return null;
+  const raw = sortParams[0];
+  const [field, direction] = raw.split(',');
+  if (!field) return null;
+  const dir = direction?.toLowerCase() === 'asc' ? 'asc' : 'desc';
+  const allowed: (keyof Link)[] = ['createdAt', 'updatedAt', 'title', 'url', 'isImportant'];
+  if (!allowed.includes(field as keyof Link)) return null;
+  return { field: field as keyof Link, direction: dir };
+}
+
+function buildSortMeta(hasSort: boolean): PageSort {
+  return {
+    unsorted: !hasSort,
+    sorted: hasSort,
+    empty: !hasSort,
+  };
+}
+
+function buildPageable(page: number, size: number, sortMeta: PageSort): Pageable {
+  return {
+    pageNumber: page,
+    pageSize: size,
+    offset: page * size,
+    paged: true,
+    unpaged: false,
+    sort: sortMeta,
+  };
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const page = Math.max(0, Number(searchParams.get('page') ?? '0') || 0);
+  const size = Math.max(1, Number(searchParams.get('size') ?? '10') || 10);
+  const sortParams = searchParams.getAll('sort');
+  const sortOption = parseSort(sortParams);
+  const hasSort = Boolean(sortOption);
+
+  const visible = links.filter(link => !link.isDeleted);
+
+  if (sortOption) {
+    visible.sort((a, b) => {
+      const { field, direction } = sortOption;
+      const aVal = a[field];
+      const bVal = b[field];
+      if (aVal === bVal) return 0;
+      if (aVal === undefined || aVal === null) return 1;
+      if (bVal === undefined || bVal === null) return -1;
+
+      let comparison = 0;
+      if (typeof aVal === 'boolean' && typeof bVal === 'boolean') {
+        comparison = aVal === bVal ? 0 : aVal ? 1 : -1;
+      } else if (typeof aVal === 'string' && typeof bVal === 'string') {
+        comparison = aVal.localeCompare(bVal);
+      } else if (typeof aVal === 'number' && typeof bVal === 'number') {
+        comparison = aVal - bVal;
+      } else {
+        // Fallback: string compare
+        comparison = String(aVal).localeCompare(String(bVal));
+      }
+
+      return direction === 'asc' ? comparison : -comparison;
+    });
+  } else {
+    visible.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  }
+
+  const totalElements = visible.length;
+  const totalPages = Math.ceil(totalElements / size);
+  const start = page * size;
+  const end = start + size;
+  const content = visible.slice(start, end);
+  const numberOfElements = content.length;
+
+  const sortMeta = buildSortMeta(hasSort);
+  const pageable = buildPageable(page, size, sortMeta);
+
+  const response: PageResponse<Link> = {
+    totalPages,
+    totalElements,
+    pageable,
+    numberOfElements,
+    size,
+    content,
+    number: page,
+    sort: sortMeta,
+    first: page === 0,
+    last: totalPages === 0 ? true : page + 1 >= totalPages,
+    empty: numberOfElements === 0,
+  };
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '200 OK',
+      message: 'ok',
+      data: response,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  );
+}
+
+export async function POST(req: Request) {
+  let body: CreateLinkPayload;
+
+  try {
+    body = (await req.json()) as CreateLinkPayload;
+  } catch {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'Invalid JSON body',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const { url, title, memo, summary, imageUrl, metadataJson, tags, isImportant } = body;
+
+  if (!url || !title) {
+    const now = new Date().toISOString();
+    return NextResponse.json(
+      {
+        success: false,
+        status: '400 BAD_REQUEST',
+        message: 'url and title are required',
+        data: null,
+        timestamp: now,
+      },
+      { status: 400 }
+    );
+  }
+
+  const timestamp = new Date().toISOString();
+  const nextId = links.reduce((max, item) => Math.max(max, item.id), 0) + 1;
+  const newLink: Link = {
+    id: nextId,
+    url,
+    title,
+    memo,
+    summary: summary ?? '',
+    imageUrl,
+    metadataJson: metadataJson ?? '{}',
+    tags: tags ?? '',
+    isImportant: isImportant ?? false,
+    isDeleted: false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+
+  links.unshift(newLink);
+
+  return NextResponse.json(
+    {
+      success: true,
+      status: '201 CREATED',
+      message: 'created',
+      data: newLink,
+      timestamp,
+    },
+    { status: 201 }
+  );
+}

--- a/src/hooks/useCheckDuplicateLink.ts
+++ b/src/hooks/useCheckDuplicateLink.ts
@@ -1,0 +1,13 @@
+import { checkDuplicateLink } from '@/apis/linkApi';
+import { useQuery } from '@tanstack/react-query';
+
+export function useCheckDuplicateLink(url: string | undefined) {
+  return useQuery<boolean, Error, boolean, ['duplicate-link', string | undefined]>({
+    queryKey: ['duplicate-link', url],
+    queryFn: () => {
+      if (!url) throw new Error('url is required');
+      return checkDuplicateLink(url);
+    },
+    enabled: Boolean(url),
+  });
+}

--- a/src/hooks/useDeleteLink.ts
+++ b/src/hooks/useDeleteLink.ts
@@ -1,0 +1,18 @@
+import { deleteLink } from '@/apis/linkApi';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useDeleteLink() {
+  const qc = useQueryClient();
+
+  return useMutation<
+    { success: boolean; status: string; message: string; data: string; timestamp: string },
+    Error,
+    number
+  >({
+    mutationFn: id => deleteLink(id),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+      qc.invalidateQueries({ queryKey: ['links', id] });
+    },
+  });
+}

--- a/src/hooks/useGetLinks.ts
+++ b/src/hooks/useGetLinks.ts
@@ -1,0 +1,15 @@
+import { type LinkListParams, fetchLinks } from '@/apis/linkApi';
+import type { Link, PageResponse } from '@/types/link';
+import { useQuery } from '@tanstack/react-query';
+
+export function useGetLinks(params?: LinkListParams) {
+  return useQuery<
+    PageResponse<Link>,
+    Error,
+    PageResponse<Link>,
+    ['links', LinkListParams | undefined]
+  >({
+    queryKey: ['links', params],
+    queryFn: () => fetchLinks(params),
+  });
+}

--- a/src/hooks/usePostLinks.ts
+++ b/src/hooks/usePostLinks.ts
@@ -1,0 +1,14 @@
+import { createLink } from '@/apis/linkApi';
+import type { CreateLinkPayload, Link } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function usePostLinks() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, CreateLinkPayload>({
+    mutationFn: createLink,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+    },
+  });
+}

--- a/src/hooks/useUpdateLink.ts
+++ b/src/hooks/useUpdateLink.ts
@@ -1,0 +1,15 @@
+import { updateLink } from '@/apis/linkApi';
+import type { Link, UpdateLinkPayload } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useUpdateLink() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, { id: number; payload: UpdateLinkPayload }>({
+    mutationFn: ({ id, payload }) => updateLink(id, payload),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+      qc.invalidateQueries({ queryKey: ['links', variables.id] });
+    },
+  });
+}

--- a/src/hooks/useUpdateLinkMemo.ts
+++ b/src/hooks/useUpdateLinkMemo.ts
@@ -1,0 +1,15 @@
+import { updateLinkMemo } from '@/apis/linkApi';
+import type { Link } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useUpdateLinkMemo() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, { id: number; memo: string }>({
+    mutationFn: ({ id, memo }) => updateLinkMemo(id, memo),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+      qc.invalidateQueries({ queryKey: ['links', variables.id] });
+    },
+  });
+}

--- a/src/hooks/useUpdateLinkTitle.ts
+++ b/src/hooks/useUpdateLinkTitle.ts
@@ -1,0 +1,14 @@
+import { updateLinkTitle } from '@/apis/linkApi';
+import type { Link } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useUpdateLinkTitle() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, { id: number; title: string }>({
+    mutationFn: ({ id, title }) => updateLinkTitle(id, title),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+    },
+  });
+}

--- a/src/types/link.ts
+++ b/src/types/link.ts
@@ -1,0 +1,54 @@
+export interface Link {
+  id: number;
+  url: string;
+  title: string;
+  summary: string;
+  memo?: string;
+  imageUrl?: string;
+  metadataJson?: string;
+  tags?: string;
+  isImportant?: boolean;
+  isDeleted?: boolean;
+  deletedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateLinkPayload = Pick<Link, 'url' | 'title'> &
+  Partial<Pick<Link, 'memo' | 'imageUrl' | 'summary' | 'metadataJson' | 'tags' | 'isImportant'>>;
+
+export type UpdateLinkPayload = Partial<
+  Pick<
+    Link,
+    'url' | 'title' | 'memo' | 'imageUrl' | 'summary' | 'metadataJson' | 'tags' | 'isImportant'
+  >
+>;
+
+export interface PageSort {
+  unsorted: boolean;
+  sorted: boolean;
+  empty: boolean;
+}
+
+export interface Pageable {
+  pageNumber: number;
+  pageSize: number;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+  sort: PageSort;
+}
+
+export interface PageResponse<T> {
+  totalPages: number;
+  totalElements: number;
+  pageable: Pageable;
+  numberOfElements: number;
+  size: number;
+  content: T[];
+  number: number;
+  sort: PageSort;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}


### PR DESCRIPTION
## 관련 이슈

- close #267

## PR 설명

- Next.js API 모킹 추가: src/app/api/links/route.ts(목록/생성, 페이지네이션, 201), src/app/api/links/[id]/route.ts(단건 조회·PUT·DELETE 소프트삭제), src/app/api/links/[id]/title/route.ts, src/app/api/links/[id]/memo/route.ts, src/app/api/links/duplicate/route.ts로 스펙 맞춘 래핑 응답(success/status/message/data/timestamp) 구현, 시드 데이터 src/app/api/links/data.ts.
- 타입 정의: src/types/link.ts에 링크 스키마와 페이지 응답 타입 추가.
- 클라이언트 API/훅: src/apis/linkApi.ts에 목록(파라미터), 단건, 생성, 업데이트, 제목/메모 수정, 삭제, 중복 체크 헬퍼 추가; 대응 React Query 훅들 src/hooks/useGetLinks.ts, usePostLinks.ts, useUpdateLink.ts, useUpdateLinkTitle.ts, useUpdateLinkMemo.ts,  useDeleteLink.ts, useCheckDuplicateLink.ts.
- 데모 UI: 사용 예시를 보여주기 위한 새 /link-api-demo 페이지(src/app/(route)/link-api-demo/page.tsx, LinkApiDemo.tsx)에서 CRUD·중복 체크를 한눈에 테스트 가능.