### PR TITLE
링크 관련 api 함수 구현 #277

### DIFF
--- a/src/apis/http.ts
+++ b/src/apis/http.ts
@@ -1,0 +1,15 @@
+export const request = async <T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  defaultErrorMessage = 'Request failed'
+): Promise<T> => {
+  const res = await fetch(input, init);
+  const errorBody = !res.ok ? await res.json().catch(() => null) : null;
+
+  if (!res.ok) {
+    const message = (errorBody as { error?: string } | null)?.error ?? defaultErrorMessage;
+    throw new Error(message);
+  }
+
+  return res.json() as Promise<T>;
+};

--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -1,0 +1,198 @@
+import type {
+  DeleteLinkApiResponse,
+  DuplicateLinkApiResponse,
+  LinkApiResponse,
+  LinkListApiData,
+  LinkListApiResponse,
+} from '@/types/api/linkApi';
+import type { CreateLinkPayload, Link, UpdateLinkPayload } from '@/types/link';
+
+import { request } from './http';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://43.200.105.93';
+const LINKS_ENDPOINT = `${API_BASE_URL}/v1/links`;
+const DEV_FALLBACK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMUBsaW5raXZpbmcuY29tIiwidG9rZW5fdHlwZSI6ImFjY2VzcyIsImlhdCI6MTc2NjA3NjEwNSwiZXhwIjo5NzY2MDc5NzA1fQ.Gmc1VkeGtG4stsg5px1tWWG7c6BU8zKjkVTpJBgaAkY';
+
+export type LinkListParams = {
+  page?: number;
+  size?: number;
+  sort?: string[] | string;
+};
+
+function buildQuery(params?: LinkListParams) {
+  if (!params) return '';
+  const usp = new URLSearchParams();
+  if (params.page !== undefined) usp.set('page', String(params.page));
+  if (params.size !== undefined) usp.set('size', String(params.size));
+  if (params.sort) {
+    const sorts = Array.isArray(params.sort) ? params.sort : [params.sort];
+    sorts.forEach(s => usp.append('sort', s));
+  }
+  const qs = usp.toString();
+  return qs ? `?${qs}` : '';
+}
+
+const withAuth = (init?: RequestInit): RequestInit => {
+  const token = process.env.NEXT_PUBLIC_API_TOKEN ?? DEV_FALLBACK_TOKEN;
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${token}`,
+    ...(init?.headers ?? {}),
+  };
+
+  return { ...init, headers };
+};
+
+const normalizeLink = (data: Partial<Link> & { imageURL?: string; timestamp?: string }): Link => {
+  const fallbackTimestamp = data.timestamp ?? new Date().toISOString();
+
+  return {
+    id: data.id ?? 0,
+    url: data.url ?? '',
+    title: data.title ?? '',
+    summary: data.summary ?? '',
+    memo: data.memo ?? undefined,
+    imageUrl: data.imageUrl ?? data.imageURL ?? '',
+    metadataJson: data.metadataJson,
+    tags: data.tags,
+    isImportant: data.isImportant,
+    isDeleted: data.isDeleted,
+    deletedAt: data.deletedAt,
+    createdAt: data.createdAt ?? fallbackTimestamp,
+    updatedAt: data.updatedAt ?? fallbackTimestamp,
+  };
+};
+
+export const fetchLinks = async (params?: LinkListParams): Promise<LinkListApiData> => {
+  const body = await request<LinkListApiResponse>(
+    `${LINKS_ENDPOINT}${buildQuery(params)}`,
+    withAuth({ cache: 'no-store' }),
+    'Failed to fetch links'
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return {
+    ...body.data,
+    content: body.data.content.map(normalizeLink),
+  };
+};
+
+export const createLink = async (payload: CreateLinkPayload): Promise<Link> => {
+  const body = await request<LinkApiResponse>(
+    LINKS_ENDPOINT,
+    withAuth({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+    'Failed to create link'
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return normalizeLink(body.data);
+};
+
+export const fetchLink = async (id: number): Promise<Link> => {
+  const body = await request<LinkApiResponse>(
+    `${LINKS_ENDPOINT}/${id}`,
+    withAuth({ cache: 'no-store' }),
+    'Failed to fetch link'
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return normalizeLink(body.data);
+};
+
+export const updateLink = async (id: number, payload: UpdateLinkPayload): Promise<Link> => {
+  const body = await request<LinkApiResponse>(
+    `${LINKS_ENDPOINT}/${id}`,
+    withAuth({
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+    'Failed to update link'
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return normalizeLink(body.data);
+};
+
+export const updateLinkTitle = async (id: number, title: string): Promise<Link> => {
+  const body = await request<LinkApiResponse>(
+    `${LINKS_ENDPOINT}/${id}/title`,
+    withAuth({
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    }),
+    'Failed to update link title'
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return normalizeLink(body.data);
+};
+
+export const updateLinkMemo = async (id: number, memo: string): Promise<Link> => {
+  const body = await request<LinkApiResponse>(
+    `${LINKS_ENDPOINT}/${id}/memo`,
+    withAuth({
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ memo }),
+    }),
+    'Failed to update link memo'
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return normalizeLink(body.data);
+};
+
+export const deleteLink = async (id: number): Promise<DeleteLinkApiResponse> => {
+  const body = await request<DeleteLinkApiResponse>(
+    `${LINKS_ENDPOINT}/${id}`,
+    withAuth({ method: 'DELETE' }),
+    'Failed to delete link'
+  );
+
+  if (!body || typeof body.success !== 'boolean' || !body.status || !body.message) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return body;
+};
+
+export const checkDuplicateLink = async (
+  url: string
+): Promise<{ exists: boolean; linkId?: number }> => {
+  const usp = new URLSearchParams({ url });
+  const body = await request<DuplicateLinkApiResponse>(
+    `${LINKS_ENDPOINT}/duplicate?${usp.toString()}`,
+    withAuth({ cache: 'no-store' }),
+    'Failed to check duplicate link'
+  );
+
+  if (!body?.data || typeof body.data.exists !== 'boolean') {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return { exists: body.data.exists, linkId: body.data.linkId };
+};

--- a/src/app/(route)/link-api-demo/LinkApiDemo.tsx
+++ b/src/app/(route)/link-api-demo/LinkApiDemo.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import Button from '@/components/basics/Button/Button';
+import Input from '@/components/basics/Input/Input';
+import Label from '@/components/basics/Label/Label';
+import TextArea from '@/components/basics/TextArea/TextArea';
+import { useCheckDuplicateLink } from '@/hooks/useCheckDuplicateLink';
+import { useDeleteLink } from '@/hooks/useDeleteLink';
+import { useGetLinks } from '@/hooks/useGetLinks';
+import { usePostLinks } from '@/hooks/usePostLinks';
+import { useUpdateLinkMemo } from '@/hooks/useUpdateLinkMemo';
+import { useUpdateLinkTitle } from '@/hooks/useUpdateLinkTitle';
+import type { Link } from '@/types/link';
+import { useEffect, useMemo, useState } from 'react';
+
+const defaultCreate = {
+  url: '',
+  title: '',
+  memo: '',
+  imageUrl: '',
+  metadataJson: '',
+  tags: '',
+  isImportant: false,
+};
+
+export default function LinkApiDemo() {
+  const [createForm, setCreateForm] = useState(defaultCreate);
+  const [duplicateUrl, setDuplicateUrl] = useState('');
+  const [duplicateQueryUrl, setDuplicateQueryUrl] = useState<string | undefined>();
+  const { data, isLoading, isError, refetch } = useGetLinks({ page: 0, size: 20 });
+  const createMut = usePostLinks();
+  const deleteMut = useDeleteLink();
+  const updateTitleMut = useUpdateLinkTitle();
+  const updateMemoMut = useUpdateLinkMemo();
+  const {
+    data: duplicateResult,
+    isFetching: isCheckingDuplicate,
+    error: duplicateError,
+  } = useCheckDuplicateLink(duplicateQueryUrl);
+
+  useEffect(() => {
+    if (createMut.isSuccess) {
+      setCreateForm(defaultCreate);
+    }
+  }, [createMut.isSuccess]);
+
+  const links = useMemo(() => data?.content ?? [], [data]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createMut.mutateAsync(createForm);
+    } catch {
+      // 에러는 createMut.isError를 통해 UI에서 표시
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteMut.mutateAsync(id);
+    } catch {
+      // 에러는 LinkCardRow 혹은 deleteMut.isError를 통해 표시
+    }
+  };
+
+  const handleUpdateTitle = async (id: number, title: string) => {
+    await updateTitleMut.mutateAsync({ id, title });
+  };
+
+  const handleUpdateMemo = async (id: number, memo: string) => {
+    await updateMemoMut.mutateAsync({ id, memo });
+  };
+
+  const handleCheckDuplicate = (e: React.FormEvent) => {
+    e.preventDefault();
+    setDuplicateQueryUrl(duplicateUrl);
+  };
+
+  const renderStatus = () => {
+    if (isLoading) return <span className="text-gray600">불러오는 중...</span>;
+    if (isError) return <span className="text-red500">목록을 불러오지 못했습니다.</span>;
+    return null;
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Link API 데모</h1>
+        <p className="text-gray600">
+          목록 조회, 생성, 제목/메모 수정, 삭제, 중복 확인을 한 눈에 확인할 수 있습니다.
+        </p>
+      </header>
+
+      {/* 생성 */}
+      <section className="border-gray200 rounded-xl border bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold">새 링크 생성</h2>
+        <form className="mt-4 grid grid-cols-2 gap-4" onSubmit={handleCreate}>
+          <div className="col-span-2 flex flex-col gap-2">
+            <Label htmlFor="create-url">URL</Label>
+            <Input
+              id="create-url"
+              value={createForm.url}
+              placeholder="https://example.com"
+              onChange={e => setCreateForm(prev => ({ ...prev, url: e.target.value }))}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="create-title">제목</Label>
+            <Input
+              id="create-title"
+              value={createForm.title}
+              placeholder="링크 제목"
+              onChange={e => setCreateForm(prev => ({ ...prev, title: e.target.value }))}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="create-tags">태그 (콤마 구분)</Label>
+            <Input
+              id="create-tags"
+              value={createForm.tags}
+              placeholder="예) 개발,자료,참고"
+              onChange={e => setCreateForm(prev => ({ ...prev, tags: e.target.value }))}
+            />
+          </div>
+          <div className="col-span-2 flex flex-col gap-2">
+            <Label htmlFor="create-memo">메모</Label>
+            <TextArea
+              id="create-memo"
+              value={createForm.memo}
+              onChange={e => setCreateForm(prev => ({ ...prev, memo: e.target.value }))}
+              placeholder="나중에 읽어볼 것"
+              heightLines={2}
+              maxHeightLines={4}
+            />
+          </div>
+          <div className="flex items-end gap-2">
+            <Button
+              type="submit"
+              label={createMut.isPending ? '생성 중...' : '생성하기'}
+              disabled={!createForm.url || !createForm.title || createMut.isPending}
+            />
+            {createMut.isError && (
+              <span className="text-red500 text-sm">생성 실패: {createMut.error?.message}</span>
+            )}
+            {createMut.isSuccess && (
+              <span className="text-green600 text-sm">생성 완료! 목록을 새로고침했습니다.</span>
+            )}
+          </div>
+        </form>
+      </section>
+
+      {/* 중복 체크 */}
+      <section className="border-gray200 rounded-xl border bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold">URL 중복 체크</h2>
+        <form className="mt-3 flex flex-wrap items-center gap-3" onSubmit={handleCheckDuplicate}>
+          <Input
+            className="min-w-80 flex-1"
+            value={duplicateUrl}
+            placeholder="중복을 확인할 URL 입력"
+            onChange={e => setDuplicateUrl(e.target.value)}
+          />
+          <Button type="submit" label={isCheckingDuplicate ? '확인 중...' : '중복 확인'} />
+          {duplicateError && <span className="text-red500 text-sm">{duplicateError.message}</span>}
+          {duplicateQueryUrl && !isCheckingDuplicate && !duplicateError && duplicateResult && (
+            <span
+              className={`text-sm ${duplicateResult.exists ? 'text-red600' : 'text-green600'}`}
+              data-testid="duplicate-result"
+            >
+              {duplicateResult.exists
+                ? `이미 존재하는 URL입니다${duplicateResult.linkId ? ` (id: ${duplicateResult.linkId})` : ''}.`
+                : '사용 가능한 URL입니다.'}
+            </span>
+          )}
+        </form>
+      </section>
+
+      {/* 목록 */}
+      <section className="border-gray200 rounded-xl border bg-white p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">링크 목록</h2>
+            <p className="text-gray600 text-sm">총 {data?.totalElements ?? 0}개</p>
+          </div>
+          <Button variant="secondary" label="새로고침" onClick={() => refetch()} />
+        </div>
+        {renderStatus()}
+        {!isLoading && links.length === 0 && (
+          <p className="text-gray600">표시할 링크가 없습니다. 새 링크를 생성해 보세요.</p>
+        )}
+        <div className="mt-2 grid gap-3 md:grid-cols-2">
+          {links.map(link => (
+            <LinkCardRow
+              key={link.id}
+              link={link}
+              onDelete={handleDelete}
+              onUpdateTitle={handleUpdateTitle}
+              onUpdateMemo={handleUpdateMemo}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LinkCardRow({
+  link,
+  onDelete,
+  onUpdateTitle,
+  onUpdateMemo,
+}: {
+  link: Link;
+  onDelete: (id: number) => Promise<void>;
+  onUpdateTitle: (id: number, title: string) => Promise<void>;
+  onUpdateMemo: (id: number, memo: string) => Promise<void>;
+}) {
+  const [nextTitle, setNextTitle] = useState(link.title);
+  const [nextMemo, setNextMemo] = useState(link.memo ?? '');
+  const [saving, setSaving] = useState<'title' | 'memo' | 'delete' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setNextTitle(link.title);
+    setNextMemo(link.memo ?? '');
+  }, [link.title, link.memo]);
+
+  const handleTitleSave = async () => {
+    setSaving('title');
+    setError(null);
+    try {
+      await onUpdateTitle(link.id, nextTitle);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleMemoSave = async () => {
+    setSaving('memo');
+    setError(null);
+    try {
+      await onUpdateMemo(link.id, nextMemo);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    setSaving('delete');
+    setError(null);
+    try {
+      await onDelete(link.id);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <div className="border-gray200 flex flex-col gap-3 rounded-lg border p-3 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col">
+          <span className="text-gray500 text-sm">#{link.id}</span>
+          <a
+            href={link.url}
+            className="text-blue600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {link.url}
+          </a>
+          <span className="text-gray500 text-xs">
+            생성: {new Date(link.createdAt).toLocaleString()}
+          </span>
+        </div>
+        <Button
+          size="sm"
+          variant="tertiary_neutral"
+          label={saving === 'delete' ? '삭제 중...' : '삭제'}
+          onClick={handleDelete}
+          disabled={saving !== null}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={`title-${link.id}`}>제목</Label>
+        <div className="flex gap-2">
+          <Input
+            id={`title-${link.id}`}
+            value={nextTitle}
+            onChange={e => setNextTitle(e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            size="sm"
+            label={saving === 'title' ? '저장 중...' : '제목 수정'}
+            onClick={handleTitleSave}
+            disabled={saving !== null}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={`memo-${link.id}`}>메모</Label>
+        <TextArea
+          id={`memo-${link.id}`}
+          value={nextMemo}
+          onChange={e => setNextMemo(e.target.value)}
+          heightLines={2}
+          maxHeightLines={4}
+        />
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="secondary"
+            label={saving === 'memo' ? '저장 중...' : '메모 수정'}
+            onClick={handleMemoSave}
+            disabled={saving !== null}
+          />
+        </div>
+      </div>
+
+      {link.tags && <p className="text-gray600 text-sm">태그: {link.tags}</p>}
+      {link.isImportant && <p className="text-amber600 text-sm">중요 표시됨</p>}
+      {error && <p className="text-red500 text-sm">오류: {error}</p>}
+    </div>
+  );
+}

--- a/src/app/(route)/link-api-demo/page.tsx
+++ b/src/app/(route)/link-api-demo/page.tsx
@@ -1,0 +1,9 @@
+import LinkApiDemo from './LinkApiDemo';
+
+export default function Page() {
+  return (
+    <main>
+      <LinkApiDemo />
+    </main>
+  );
+}

--- a/src/hooks/useCheckDuplicateLink.ts
+++ b/src/hooks/useCheckDuplicateLink.ts
@@ -1,0 +1,15 @@
+import { checkDuplicateLink } from '@/apis/linkApi';
+import { useQuery } from '@tanstack/react-query';
+
+type DuplicateResult = { exists: boolean; linkId?: number };
+
+export function useCheckDuplicateLink(url: string | undefined) {
+  return useQuery<DuplicateResult, Error, DuplicateResult, ['duplicate-link', string | undefined]>({
+    queryKey: ['duplicate-link', url],
+    queryFn: () => {
+      if (!url) throw new Error('url is required');
+      return checkDuplicateLink(url);
+    },
+    enabled: Boolean(url),
+  });
+}

--- a/src/hooks/useDeleteLink.ts
+++ b/src/hooks/useDeleteLink.ts
@@ -1,0 +1,15 @@
+import { deleteLink } from '@/apis/linkApi';
+import type { DeleteLinkApiResponse } from '@/types/api/linkApi';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useDeleteLink() {
+  const qc = useQueryClient();
+
+  return useMutation<DeleteLinkApiResponse, Error, number>({
+    mutationFn: id => deleteLink(id),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+      qc.invalidateQueries({ queryKey: ['links', id] });
+    },
+  });
+}

--- a/src/hooks/useGetLinks.ts
+++ b/src/hooks/useGetLinks.ts
@@ -1,0 +1,10 @@
+import { type LinkListParams, fetchLinks } from '@/apis/linkApi';
+import type { LinkListApiData } from '@/types/api/linkApi';
+import { useQuery } from '@tanstack/react-query';
+
+export function useGetLinks(params?: LinkListParams) {
+  return useQuery<LinkListApiData, Error, LinkListApiData, ['links', LinkListParams | undefined]>({
+    queryKey: ['links', params],
+    queryFn: () => fetchLinks(params),
+  });
+}

--- a/src/hooks/usePostLinks.ts
+++ b/src/hooks/usePostLinks.ts
@@ -1,0 +1,14 @@
+import { createLink } from '@/apis/linkApi';
+import type { CreateLinkPayload, Link } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function usePostLinks() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, CreateLinkPayload>({
+    mutationFn: createLink,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+    },
+  });
+}

--- a/src/hooks/useUpdateLink.ts
+++ b/src/hooks/useUpdateLink.ts
@@ -1,0 +1,15 @@
+import { updateLink } from '@/apis/linkApi';
+import type { Link, UpdateLinkPayload } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useUpdateLink() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, { id: number; payload: UpdateLinkPayload }>({
+    mutationFn: ({ id, payload }) => updateLink(id, payload),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+      qc.invalidateQueries({ queryKey: ['links', variables.id] });
+    },
+  });
+}

--- a/src/hooks/useUpdateLinkMemo.ts
+++ b/src/hooks/useUpdateLinkMemo.ts
@@ -1,0 +1,15 @@
+import { updateLinkMemo } from '@/apis/linkApi';
+import type { Link } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useUpdateLinkMemo() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, { id: number; memo: string }>({
+    mutationFn: ({ id, memo }) => updateLinkMemo(id, memo),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+      qc.invalidateQueries({ queryKey: ['links', variables.id] });
+    },
+  });
+}

--- a/src/hooks/useUpdateLinkTitle.ts
+++ b/src/hooks/useUpdateLinkTitle.ts
@@ -1,0 +1,14 @@
+import { updateLinkTitle } from '@/apis/linkApi';
+import type { Link } from '@/types/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useUpdateLinkTitle() {
+  const qc = useQueryClient();
+
+  return useMutation<Link, Error, { id: number; title: string }>({
+    mutationFn: ({ id, title }) => updateLinkTitle(id, title),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['links'] });
+    },
+  });
+}

--- a/src/types/api/linkApi.ts
+++ b/src/types/api/linkApi.ts
@@ -1,0 +1,36 @@
+import type { Link, PageSort, Pageable } from '@/types/link';
+
+export interface ApiResponseBase<T> {
+  success: boolean;
+  status: string;
+  message: string;
+  data: T;
+  timestamp?: string;
+}
+
+export type LinkApiData = Link;
+
+export type LinkApiResponse = ApiResponseBase<LinkApiData>;
+
+export interface LinkListApiData {
+  totalPages: number;
+  totalElements: number;
+  pageable: Pageable;
+  numberOfElements: number;
+  size: number;
+  content: LinkApiData[];
+  number: number;
+  sort: PageSort;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}
+
+export type LinkListApiResponse = ApiResponseBase<LinkListApiData>;
+
+export type DeleteLinkApiResponse = ApiResponseBase<string> & { timestamp: string };
+
+export type DuplicateLinkApiResponse = ApiResponseBase<{
+  exists: boolean;
+  linkId?: number;
+}>;

--- a/src/types/link.ts
+++ b/src/types/link.ts
@@ -1,0 +1,67 @@
+export interface Link {
+  id: number;
+  url: string;
+  title: string;
+  summary: string;
+  memo?: string;
+  imageUrl?: string;
+  metadataJson?: string;
+  tags?: string;
+  isImportant?: boolean;
+  isDeleted?: boolean;
+  deletedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type AtLeastOne<T, Keys extends keyof T = keyof T> = Partial<T> &
+  { [K in Keys]-?: Required<Pick<T, K>> & Partial<Omit<T, K>> }[Keys];
+
+type OptionalLinkFields = Pick<
+  Link,
+  'memo' | 'imageUrl' | 'summary' | 'metadataJson' | 'tags' | 'isImportant'
+>;
+
+export type CreateLinkPayload = Pick<Link, 'url' | 'title'> & Partial<OptionalLinkFields>;
+
+type UpdatableLinkFields = {
+  url?: string | null;
+  title?: string | null;
+  memo?: string | null;
+  imageUrl?: string | null;
+  summary?: string | null;
+  metadataJson?: string | null;
+  tags?: string | null;
+  isImportant?: boolean | null;
+};
+
+export type UpdateLinkPayload = AtLeastOne<UpdatableLinkFields>;
+
+export interface PageSort {
+  unsorted: boolean;
+  sorted: boolean;
+  empty: boolean;
+}
+
+export interface Pageable {
+  pageNumber: number;
+  pageSize: number;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+  sort: PageSort;
+}
+
+export interface PageResponse<T> {
+  totalPages: number;
+  totalElements: number;
+  pageable: Pageable;
+  numberOfElements: number;
+  size: number;
+  content: T[];
+  number: number;
+  sort: PageSort;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}


### PR DESCRIPTION
## 관련 이슈

- close #267 

## PR 설명
- Link API 클라이언트와 훅을 추가해 목록 조회/생성/수정/삭제, 제목·메모 업데이트, 중복 검사까지 모두 처리하도록 했습니다.
- Next.js API 라우트(src/app/api/links)를 모킹으로 구현해 인메모리 링크 데이터를 CRUD/중복 확인할 수 있게 했습니다.
- React Query 기반 데모 페이지(src/app/(route)/link-api-demo)를 추가해 생성, 리스트 조회·리프레시, 제목·메모 수정, 삭제, 중복 확인 흐름을 UI로 검증할 수 있습니다.

Tests: not run (not requested).