### PR TITLE
mock 데이터 추가 및 전체 링크 페이지 목업

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -2,8 +2,8 @@ import type {
   DeleteLinkApiResponse,
   DuplicateLinkApiResponse,
   LinkApiResponse,
-  LinkListApiData,
   LinkListApiResponse,
+  LinkListViewData,
 } from '@/types/api/linkApi';
 import type { CreateLinkPayload, Link, UpdateLinkPayload } from '@/types/link';
 
@@ -43,8 +43,8 @@ const withAuth = (init?: RequestInit): RequestInit => {
   return { ...init, headers };
 };
 
-const normalizeLink = (data: Partial<Link> & { imageURL?: string; timestamp?: string }): Link => {
-  const fallbackTimestamp = data.timestamp ?? new Date().toISOString();
+const normalizeLink = (data: Partial<Link>): Link => {
+  const now = new Date().toISOString();
 
   return {
     id: data.id ?? 0,
@@ -52,18 +52,13 @@ const normalizeLink = (data: Partial<Link> & { imageURL?: string; timestamp?: st
     title: data.title ?? '',
     summary: data.summary ?? '',
     memo: data.memo ?? undefined,
-    imageUrl: data.imageUrl ?? data.imageURL ?? '',
-    metadataJson: data.metadataJson,
-    tags: data.tags,
-    isImportant: data.isImportant,
-    isDeleted: data.isDeleted,
-    deletedAt: data.deletedAt,
-    createdAt: data.createdAt ?? fallbackTimestamp,
-    updatedAt: data.updatedAt ?? fallbackTimestamp,
+    imageUrl: data.imageUrl ?? '',
+    createdAt: data.createdAt ?? now,
+    updatedAt: data.updatedAt ?? now,
   };
 };
 
-export const fetchLinks = async (params?: LinkListParams): Promise<LinkListApiData> => {
+export const fetchLinks = async (params?: LinkListParams): Promise<LinkListViewData> => {
   const body = await request<LinkListApiResponse>(
     `${LINKS_ENDPOINT}${buildQuery(params)}`,
     withAuth({ cache: 'no-store' }),

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -1,7 +1,69 @@
+'use client';
+
+import LinkCard from '@/components/basics/LinkCard/LinkCard';
+import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
+import { useLinkStore } from '@/stores/linkStore';
+import { useState } from 'react';
+
 export default function AllLink() {
+  const { links, selectedLinkId, selectLink } = useLinkStore();
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
+  const selectedLink = links.find(link => link.id === selectedLinkId) ?? null;
+
+  const handleSelectLink = (id: number) => {
+    selectLink(id);
+    setIsPanelOpen(true);
+  };
+
   return (
-    <div>
-      <p>This is the all link page.</p>
+    <div className="min-h-screen min-w-0">
+      <div className="min-h-screen min-w-0 xl:flex">
+        <div className="min-w-0 flex-1 px-6 py-8 lg:px-10">
+          <div className="mx-auto flex w-full max-w-200 flex-col gap-6">
+            <header>
+              <h1 className="text-2xl font-semibold">전체 링크</h1>
+              <p className="text-gray600 text-sm">
+                저장된 링크를 모아보고, 우측 패널에서 상세 정보를 확인할 수 있어요.
+              </p>
+            </header>
+            {links.length === 0 ? (
+              <p className="text-gray600">표시할 링크가 없습니다.</p>
+            ) : (
+              <div className="grid min-w-0 grid-cols-2 justify-center justify-items-center gap-4 md:grid-cols-3 xl:grid-cols-4">
+                {links.map(link => (
+                  <LinkCard
+                    key={link.id}
+                    title={link.title}
+                    link={link.url}
+                    summary={link.summary ?? ''}
+                    imageUrl={link.imageUrl ?? ''}
+                    onClick={() => handleSelectLink(link.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        {isPanelOpen && (
+          <aside className="hidden h-screen shrink-0 xl:block xl:w-130">
+            {selectedLink ? (
+              <LinkCardDetailPanel
+                url={selectedLink.url}
+                title={selectedLink.title}
+                summary={selectedLink.summary ?? ''}
+                memo={selectedLink.memo ?? ''}
+                imageUrl={selectedLink.imageUrl}
+                onClose={() => setIsPanelOpen(false)}
+              />
+            ) : (
+              <div className="border-gray200 text-gray600 h-full rounded-2xl border bg-white p-6">
+                상세 정보를 볼 링크를 선택해 주세요.
+              </div>
+            )}
+          </aside>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/(route)/link-api-demo/LinkApiDemo.tsx
+++ b/src/app/(route)/link-api-demo/LinkApiDemo.tsx
@@ -18,9 +18,6 @@ const defaultCreate = {
   title: '',
   memo: '',
   imageUrl: '',
-  metadataJson: '',
-  tags: '',
-  isImportant: false,
 };
 
 export default function LinkApiDemo() {
@@ -113,15 +110,6 @@ export default function LinkApiDemo() {
               placeholder="링크 제목"
               onChange={e => setCreateForm(prev => ({ ...prev, title: e.target.value }))}
               required
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="create-tags">태그 (콤마 구분)</Label>
-            <Input
-              id="create-tags"
-              value={createForm.tags}
-              placeholder="예) 개발,자료,참고"
-              onChange={e => setCreateForm(prev => ({ ...prev, tags: e.target.value }))}
             />
           </div>
           <div className="col-span-2 flex flex-col gap-2">
@@ -326,8 +314,6 @@ function LinkCardRow({
         </div>
       </div>
 
-      {link.tags && <p className="text-gray600 text-sm">태그: {link.tags}</p>}
-      {link.isImportant && <p className="text-amber600 text-sm">중요 표시됨</p>}
       {error && <p className="text-red500 text-sm">오류: {error}</p>}
     </div>
   );

--- a/src/hooks/useGetLinks.ts
+++ b/src/hooks/useGetLinks.ts
@@ -1,10 +1,12 @@
 import { type LinkListParams, fetchLinks } from '@/apis/linkApi';
-import type { LinkListApiData } from '@/types/api/linkApi';
+import type { LinkListViewData } from '@/types/api/linkApi';
 import { useQuery } from '@tanstack/react-query';
 
 export function useGetLinks(params?: LinkListParams) {
-  return useQuery<LinkListApiData, Error, LinkListApiData, ['links', LinkListParams | undefined]>({
-    queryKey: ['links', params],
-    queryFn: () => fetchLinks(params),
-  });
+  return useQuery<LinkListViewData, Error, LinkListViewData, ['links', LinkListParams | undefined]>(
+    {
+      queryKey: ['links', params],
+      queryFn: () => fetchLinks(params),
+    }
+  );
 }

--- a/src/mocks/fixtures/chatMessages.ts
+++ b/src/mocks/fixtures/chatMessages.ts
@@ -1,0 +1,66 @@
+export type ChatRole = 'user' | 'assistant';
+
+export interface ChatMessage {
+  id: string;
+  chatId: number;
+  role: ChatRole;
+  content: string;
+  createdAt: string;
+}
+
+const now = new Date();
+const iso = (offsetMinutes: number) =>
+  new Date(now.getTime() + offsetMinutes * 60000).toISOString();
+
+export const chatHistoryById: Record<number, ChatMessage[]> = {
+  201: [
+    {
+      id: '201-1',
+      chatId: 201,
+      role: 'user',
+      content: '웹 접근성 기준을 요약해줘.',
+      createdAt: iso(-90),
+    },
+    {
+      id: '201-2',
+      chatId: 201,
+      role: 'assistant',
+      content:
+        '웹 접근성은 누구나 웹을 사용할 수 있도록 만드는 기준입니다. 인지/운용/이해/견고성의 4원칙을 기준으로 대비, 키보드 접근성, 대체 텍스트 등을 확인합니다.',
+      createdAt: iso(-89),
+    },
+  ],
+  202: [
+    {
+      id: '202-1',
+      chatId: 202,
+      role: 'user',
+      content: 'AI 관련 링크 좀 찾아줘.',
+      createdAt: iso(-70),
+    },
+    {
+      id: '202-2',
+      chatId: 202,
+      role: 'assistant',
+      content: '최근 저장된 링크 중 AI 로드맵과 트렌드 관련 자료를 정리해줄게요.',
+      createdAt: iso(-69),
+    },
+  ],
+  203: [
+    {
+      id: '203-1',
+      chatId: 203,
+      role: 'user',
+      content: '요즘 IT 트렌드를 한 문단으로 요약해줘.',
+      createdAt: iso(-50),
+    },
+    {
+      id: '203-2',
+      chatId: 203,
+      role: 'assistant',
+      content:
+        'AI 도입 속도 증가, 보안/프라이버시 강화, 개인화 UX 확대, 그리고 개발 생산성 도구의 확산이 주요 흐름으로 보입니다.',
+      createdAt: iso(-49),
+    },
+  ],
+};

--- a/src/mocks/fixtures/chats.ts
+++ b/src/mocks/fixtures/chats.ts
@@ -1,0 +1,29 @@
+import type {
+  ChatSummary,
+  ChatsApiResponse,
+  ChatsRes,
+  CreateChatApiResponse,
+} from '@/types/api/chatApi';
+
+import { buildResponse } from '../response';
+
+export const mockChats: ChatSummary[] = [
+  { id: 201, title: '웹 접근성 요약 요청' },
+  { id: 202, title: 'AI 관련 링크 찾아줘' },
+  { id: 203, title: '요즘 IT 트렌드 정리' },
+  { id: 204, title: '건강한 식단 링크' },
+  { id: 205, title: '개발 자료 북마크' },
+  { id: 206, title: '회의록 템플릿 질문' },
+];
+
+export const mockChatsData: ChatsRes = {
+  chats: mockChats,
+};
+
+export const mockChatsResponse: ChatsApiResponse = buildResponse(mockChatsData);
+
+export const buildCreateChatResponse = (input: {
+  id: number;
+  title: string;
+  firstChat: string;
+}): CreateChatApiResponse => buildResponse(input, { status: '201 CREATED', message: 'Created' });

--- a/src/mocks/fixtures/links.ts
+++ b/src/mocks/fixtures/links.ts
@@ -1,0 +1,141 @@
+import type { LinkApiData, LinkListApiData, LinkListApiResponse } from '@/types/api/linkApi';
+import type { PageSort, Pageable } from '@/types/link';
+
+import { buildResponse } from '../response';
+
+const pageSort: PageSort = {
+  unsorted: true,
+  sorted: false,
+  empty: true,
+};
+
+const pageable: Pageable = {
+  pageNumber: 0,
+  pageSize: 12,
+  offset: 0,
+  paged: true,
+  unpaged: false,
+  sort: pageSort,
+};
+
+export const mockLinks: LinkApiData[] = [
+  {
+    id: 101,
+    url: 'https://examples.design/clean-layouts',
+    title: '복잡한 대시보드를 위한 깔끔한 레이아웃',
+    summary:
+      '정보 밀도가 높은 대시보드에서도 읽기 쉬운 레이아웃 패턴을 정리했습니다. 카드, 표, 필터, 차트가 함께 있을 때 계층을 어떻게 나누고, 어떤 여백을 유지해야 읽기 흐름이 끊기지 않는지 사례 중심으로 설명합니다.',
+    memo: '관리자 UI 기준안으로 참고. 실제 운영 화면에서 빈번히 발생하는 밀집 레이아웃 케이스를 포함하고 있어, 내부 디자인 가이드 문서에도 인용하기 좋습니다.',
+    imageUrl: 'https://images.unsplash.com/photo-1487014679447-9f8336841d58',
+  },
+  {
+    id: 102,
+    url: 'https://developer.mozilla.org/en-US/docs/Web/Accessibility',
+    title: '웹 접근성 기초',
+    summary:
+      '접근성을 위한 핵심 원칙, 도구, 실무 체크리스트를 정리했습니다. 스크린 리더 대응, 키보드 포커스 순서, 색 대비, 대체 텍스트 작성 요령까지 포함하고 있어 QA 체크리스트로 바로 사용 가능합니다.',
+    memo: '접근성 리포트 참고. 대비/포커스/대체 텍스트 관련 항목은 체크리스트로 바로 옮겨 써도 될 정도로 정리되어 있습니다.',
+    imageUrl: 'https://images.unsplash.com/photo-1454165804606-c3d57bc86b40',
+  },
+  {
+    id: 103,
+    url: 'https://growth.design/case-studies',
+    title: '온보딩 케이스 스터디 모음',
+    summary: '',
+    memo: '요약 생성 중.',
+    imageUrl: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa',
+  },
+  {
+    id: 104,
+    url: 'https://brunchstory.com/post/healthy-meals',
+    title: '바쁜 평일을 위한 건강 식단',
+    summary:
+      '단백질 중심, 준비 시간 최소화, 주간 계획에 맞춘 식단 아이디어. 재료 구매 리스트부터 한 주 식단 배치 예시, 남는 재료 재활용 팁까지 포함해 바로 적용할 수 있도록 구성했습니다.',
+    memo: '라이프스타일 카테고리용. 카드 뷰에서는 요약을 길게 보여도 좋고, 상세 패널에서는 식단 플로우를 단계별로 보여주면 좋을 듯.',
+    imageUrl: 'https://images.unsplash.com/photo-1466978913421-dad2ebd01d17',
+  },
+  {
+    id: 105,
+    url: 'https://velog.io/@sample/productivity',
+    title: '주간 생산성 회고',
+    summary: '',
+    memo: '요약 생성 실패.',
+    imageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4',
+  },
+  {
+    id: 106,
+    url: 'https://uibowl.io/recipes',
+    title: '모던 앱을 위한 레시피 카드',
+    summary: '음식/레시피 탐색에 맞춘 카드 UI 패턴 모음입니다.',
+    memo: '레퍼런스로 저장.',
+    imageUrl: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef',
+  },
+  {
+    id: 107,
+    url: 'https://examples.design/brand-voice',
+    title: '일관된 브랜드 톤 구축',
+    summary:
+      '제품/마케팅 카피 톤을 맞추는 실무 단계 정리. 브랜드 핵심 가치 정의, 금지/권장 표현, 보이스 차트 작성 예시를 포함해 신규 페이지 작성 시 참고하기 좋습니다.',
+    memo: '콘텐츠 팀 공유.',
+    imageUrl: 'https://images.unsplash.com/photo-1529333166437-7750a6dd5a70',
+  },
+  {
+    id: 108,
+    url: 'https://tech.example.com/ai-roadmap',
+    title: '팀을 위한 AI 로드맵',
+    summary: '',
+    memo: '요약 대기 중.',
+    imageUrl: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085',
+  },
+  {
+    id: 109,
+    url: 'https://examples.design/white-space',
+    title: '정보 밀도 높은 레이아웃의 여백',
+    summary:
+      '여백을 활용해 정보 밀도를 유지하면서도 읽기 쉬운 구성 방법. 카드 간 간격, 섹션 분리, 정보 덩어리 크기 조절 기준을 단계적으로 정리했습니다.',
+    memo: '레이아웃 QA 참고.',
+    imageUrl: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085',
+  },
+  {
+    id: 110,
+    url: 'https://design.example.com/typography',
+    title: '제품을 위한 타이포그래피 시스템',
+    summary: '계층과 가독성을 중심으로 한 확장 가능한 타이포 시스템 가이드.',
+    memo: '디자인 시스템 참고.',
+    imageUrl: 'https://images.unsplash.com/photo-1487014679447-9f8336841d58',
+  },
+  {
+    id: 111,
+    url: 'https://wellness.example.com/sleep',
+    title: '수면 최적화 기본',
+    summary: '수면의 질과 아침 에너지를 높이는 습관과 루틴 정리.',
+    memo: '라이프스타일 콘텐츠.',
+    imageUrl: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d',
+  },
+  {
+    id: 112,
+    url: 'https://work.example.com/meeting-notes',
+    title: '회의록 템플릿',
+    summary: '',
+    memo: '요약 요청 전.',
+    imageUrl: 'https://images.unsplash.com/photo-1485217988980-11786ced9454',
+  },
+];
+
+export const mockLinkListData: LinkListApiData = {
+  totalPages: 1,
+  totalElements: mockLinks.length,
+  pageable,
+  numberOfElements: mockLinks.length,
+  size: pageable.pageSize,
+  content: mockLinks,
+  number: pageable.pageNumber,
+  sort: pageSort,
+  first: true,
+  last: true,
+  empty: mockLinks.length === 0,
+};
+
+export const mockLinkListResponse: LinkListApiResponse = buildResponse(mockLinkListData);
+
+export const mockLinkById = (id: number) => mockLinks.find(link => link.id === id) ?? null;

--- a/src/mocks/fixtures/summaryStatus.ts
+++ b/src/mocks/fixtures/summaryStatus.ts
@@ -1,0 +1,41 @@
+import type { LinkSummaryStatus } from '@/types/link';
+
+export interface SummaryStatusEvent {
+  linkId: number;
+  status: LinkSummaryStatus;
+  progress?: number;
+  summary?: string;
+  updatedAt: string;
+}
+
+const now = new Date().toISOString();
+
+export const mockSummaryStatusEvents: SummaryStatusEvent[] = [
+  { linkId: 103, status: 'generating', progress: 45, updatedAt: now },
+  { linkId: 108, status: 'generating', progress: 10, updatedAt: now },
+  {
+    linkId: 105,
+    status: 'failed',
+    summary: '요약 생성에 실패했습니다. 다시 시도해 주세요.',
+    updatedAt: now,
+  },
+  {
+    linkId: 112,
+    status: 'idle',
+    updatedAt: now,
+  },
+  {
+    linkId: 101,
+    status: 'ready',
+    summary:
+      'A quick overview of layout patterns that keep dense dashboards scannable and consistent.',
+    updatedAt: now,
+  },
+  {
+    linkId: 103,
+    status: 'ready',
+    summary:
+      '온보딩 흐름에서 첫 사용 경험을 개선하기 위한 주요 패턴과 UI 구성 요소를 요약했습니다.',
+    updatedAt: now,
+  },
+];

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,5 @@
+export * from './fixtures/chats';
+export * from './fixtures/chatMessages';
+export * from './fixtures/links';
+export * from './fixtures/summaryStatus';
+export * from './response';

--- a/src/mocks/response.ts
+++ b/src/mocks/response.ts
@@ -1,0 +1,23 @@
+import type { ApiResponseBase } from '@/types/api/linkApi';
+
+type Status = '200 OK' | '201 CREATED' | '400 BAD_REQUEST' | '500 INTERNAL_SERVER_ERROR';
+
+export const buildResponse = <T>(
+  data: T,
+  opts?: {
+    success?: boolean;
+    status?: Status;
+    message?: string;
+    timestamp?: string;
+  }
+): ApiResponseBase<T> => {
+  const now = new Date().toISOString();
+
+  return {
+    success: opts?.success ?? true,
+    status: opts?.status ?? '200 OK',
+    message: opts?.message ?? 'OK',
+    data,
+    timestamp: opts?.timestamp ?? now,
+  };
+};

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,0 +1,30 @@
+import { mockChats } from '@/mocks';
+import type { ChatSummary } from '@/types/api/chatApi';
+import { create } from 'zustand';
+
+type ChatStoreState = {
+  chats: ChatSummary[];
+  activeChatId: number | null;
+  setChats: (chats: ChatSummary[]) => void;
+  addChat: (chat: ChatSummary) => void;
+  removeChat: (id: number) => void;
+  setActiveChat: (id: number | null) => void;
+};
+
+const useMockData = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+
+export const useChatStore = create<ChatStoreState>(set => ({
+  chats: useMockData ? mockChats : [],
+  activeChatId: null,
+  setChats: chats => set({ chats }),
+  addChat: chat =>
+    set(state => ({
+      chats: [chat, ...state.chats],
+    })),
+  removeChat: id =>
+    set(state => ({
+      chats: state.chats.filter(chat => chat.id !== id),
+      activeChatId: state.activeChatId === id ? null : state.activeChatId,
+    })),
+  setActiveChat: id => set({ activeChatId: id }),
+}));

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -1,0 +1,24 @@
+import { mockLinks } from '@/mocks';
+import type { LinkApiData } from '@/types/api/linkApi';
+import { create } from 'zustand';
+
+type LinkStoreState = {
+  links: LinkApiData[];
+  selectedLinkId: number | null;
+  setLinks: (links: LinkApiData[]) => void;
+  selectLink: (id: number | null) => void;
+  updateLink: (id: number, updates: Partial<LinkApiData>) => void;
+};
+
+const useMockData = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+
+export const useLinkStore = create<LinkStoreState>(set => ({
+  links: useMockData ? mockLinks : [],
+  selectedLinkId: null,
+  setLinks: links => set({ links }),
+  selectLink: id => set({ selectedLinkId: id }),
+  updateLink: (id, updates) =>
+    set(state => ({
+      links: state.links.map(link => (link.id === id ? { ...link, ...updates } : link)),
+    })),
+}));

--- a/src/types/api/chatApi.ts
+++ b/src/types/api/chatApi.ts
@@ -1,0 +1,26 @@
+import type { ApiResponseBase } from '@/types/api/linkApi';
+
+export interface ChatSummary {
+  id: number;
+  title: string;
+}
+
+export interface ChatsRes {
+  chats: ChatSummary[];
+}
+
+export type ChatsApiResponse = ApiResponseBase<ChatsRes>;
+
+export interface CreateChatReq {
+  firstChat: string;
+}
+
+export interface CreateChatRes {
+  id: number;
+  title: string;
+  firstChat: string;
+}
+
+export type CreateChatApiResponse = ApiResponseBase<CreateChatRes>;
+
+export type DeleteChatApiResponse = ApiResponseBase<string>;

--- a/src/types/api/linkApi.ts
+++ b/src/types/api/linkApi.ts
@@ -8,7 +8,16 @@ export interface ApiResponseBase<T> {
   timestamp?: string;
 }
 
-export type LinkApiData = Link;
+export interface LinkRes {
+  id: number;
+  url: string;
+  title: string;
+  summary?: string;
+  memo?: string;
+  imageUrl?: string;
+}
+
+export type LinkApiData = LinkRes;
 
 export type LinkApiResponse = ApiResponseBase<LinkApiData>;
 
@@ -27,6 +36,10 @@ export interface LinkListApiData {
 }
 
 export type LinkListApiResponse = ApiResponseBase<LinkListApiData>;
+
+export type LinkListViewData = Omit<LinkListApiData, 'content'> & {
+  content: Link[];
+};
 
 export type DeleteLinkApiResponse = ApiResponseBase<string> & { timestamp: string };
 

--- a/src/types/link.ts
+++ b/src/types/link.ts
@@ -1,15 +1,18 @@
-export interface Link {
+export type LinkSummaryStatus = 'idle' | 'generating' | 'ready' | 'failed';
+
+export interface LinkSummaryState {
+  summaryStatus?: LinkSummaryStatus;
+  summaryProgress?: number;
+  summaryUpdatedAt?: string;
+}
+
+export interface Link extends LinkSummaryState {
   id: number;
   url: string;
   title: string;
   summary: string;
   memo?: string;
   imageUrl?: string;
-  metadataJson?: string;
-  tags?: string;
-  isImportant?: boolean;
-  isDeleted?: boolean;
-  deletedAt?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -17,22 +20,13 @@ export interface Link {
 export type AtLeastOne<T, Keys extends keyof T = keyof T> = Partial<T> &
   { [K in Keys]-?: Required<Pick<T, K>> & Partial<Omit<T, K>> }[Keys];
 
-type OptionalLinkFields = Pick<
-  Link,
-  'memo' | 'imageUrl' | 'summary' | 'metadataJson' | 'tags' | 'isImportant'
->;
+type OptionalLinkFields = Pick<Link, 'memo' | 'imageUrl'>;
 
 export type CreateLinkPayload = Pick<Link, 'url' | 'title'> & Partial<OptionalLinkFields>;
 
 type UpdatableLinkFields = {
-  url?: string | null;
   title?: string | null;
   memo?: string | null;
-  imageUrl?: string | null;
-  summary?: string | null;
-  metadataJson?: string | null;
-  tags?: string | null;
-  isImportant?: boolean | null;
 };
 
 export type UpdateLinkPayload = AtLeastOne<UpdatableLinkFields>;


### PR DESCRIPTION
## 관련 이슈

- close #286

## PR 설명
- UI mock 기반으로 링크/채팅 데이터를 준비하고, 전체 링크 페이지에서 실제 컴포넌트 배치를 검증함.
### Changes
- 링크/채팅 mock fixtures 및 zustand store 추가
- Swagger 스펙 반영한 링크 API 타입 정리
- `/all-link`에서 카드 그리드 + 우측 상세 패널 레이아웃 구성, 패널 닫기 동작 추가

### Notes
- `NEXT_PUBLIC_USE_MOCKS=true`일 때 mock 초기값 사용
  -  `NEXT_PUBLIC_USE_MOCKS=true pnpm dev`