### PR TITLE
안쓰는 import 자동 삭제 플러그인 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import prettierPlugin from 'eslint-plugin-prettier';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import storybookPlugin from 'eslint-plugin-storybook';
+import unusedImports from 'eslint-plugin-unused-imports';
 import validateFilename from 'eslint-plugin-validate-filename';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -42,6 +43,7 @@ const config = [
       'jsx-a11y': jsxA11yPlugin,
       storybook: storybookPlugin,
       'validate-filename': validateFilename,
+      'unused-imports': unusedImports,
     },
     languageOptions: {
       parserOptions: {
@@ -51,15 +53,7 @@ const config = [
     },
     rules: {
       'react/react-in-jsx-scope': 'off',
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          vars: 'all',
-          varsIgnorePattern: '^_',
-          args: 'after-used',
-          argsIgnorePattern: '^_',
-        },
-      ],
+      '@typescript-eslint/no-unused-vars': 'off',
       'require-jsdoc': 'off',
       'react/display-name': 'off',
       'react-hooks/exhaustive-deps': 'warn',
@@ -88,6 +82,7 @@ const config = [
           ],
         },
       ],
+      'unused-imports/no-unused-imports': 'error',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-storybook": "^10.1.4",
+    "eslint-plugin-unused-imports": "^4.3.0",
     "eslint-plugin-validate-filename": "^1.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       eslint-plugin-storybook:
         specifier: ^10.1.4
         version: 10.1.4(eslint@9.39.1(jiti@2.6.1))(storybook@10.1.4(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
+      eslint-plugin-unused-imports:
+        specifier: ^4.3.0
+        version: 4.3.0(@typescript-eslint/eslint-plugin@8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-validate-filename:
         specifier: ^1.2.0
         version: 1.2.0(eslint@9.39.1(jiti@2.6.1))
@@ -3129,6 +3132,15 @@ packages:
     peerDependencies:
       eslint: '>=8'
       storybook: ^10.1.4
+
+  eslint-plugin-unused-imports@4.3.0:
+    resolution: {integrity: sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-plugin-validate-filename@1.2.0:
     resolution: {integrity: sha512-vh6SoDW5vK6YzbvH6MLDeRzR+pI66ATi8DHqPLzqexIkQv6R86eKLNrjfV77KgzaMv5AgoAB1mRJus8lnFDV7g==}
@@ -8896,6 +8908,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-plugin-validate-filename@1.2.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:


### PR DESCRIPTION
## 관련 이슈

- close #311

## PR 설명
- `eslint-plugin-unused-imports`를 설치하여 `eslint --fix` 실행 시, 사용하지 않는 import 구문을 자동 삭제하도록 합니다.