### PR TITLE
popover outsideclick 에러 해결

### DIFF
--- a/src/components/basics/Popover/Content.tsx
+++ b/src/components/basics/Popover/Content.tsx
@@ -1,46 +1,50 @@
 'use client';
 
+import { useOutsideClick } from '@/hooks/util/useOutsideClickHandler';
 import clsx from 'clsx';
-import React from 'react';
+import React, { useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { usePopover } from './PopoverContext';
 import { usePopoverPosition } from './hooks/usePopoverPosition';
 
 interface PopoverContentProps {
-  children: React.ReactNode;
+  children: (close: () => void) => React.ReactNode;
   popoverKey: string;
   className?: string;
 }
 
 const PopoverContent = ({ children, popoverKey, className }: PopoverContentProps) => {
-  const { activeKey, anchorEl, placement } = usePopover();
+  const { activeKey, anchorEl, placement, close } = usePopover();
 
-  const triggerRef = anchorEl ?? null;
   const isActive = activeKey === popoverKey;
 
-  const { refs, floatingStyles } = usePopoverPosition(triggerRef, isActive, placement);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const anchorRef = useRef<HTMLElement | null>(null);
+  anchorRef.current = anchorEl ?? null;
+
+  const { refs, floatingStyles } = usePopoverPosition(anchorRef.current, isActive, placement);
+
+  useOutsideClick([contentRef, anchorRef], close, isActive);
 
   if (!isActive) return null;
 
-  const portalEl = typeof window !== 'undefined' ? document.body : null;
-
-  return portalEl
-    ? createPortal(
-        <div
-          ref={refs.setFloating}
-          style={floatingStyles}
-          className={clsx(
-            'border-gray100 bg-gray50 z-50 m-1 rounded-2xl border shadow-[0_1px_3px_1px_rgba(0,0,0,0.08),0_1px_5px_2px_rgba(0,0,0,0.02)]',
-            className
-          )}
-          onClick={e => e.stopPropagation()}
-        >
-          {children}
-        </div>,
-        portalEl
-      )
-    : null;
+  return createPortal(
+    <div
+      ref={node => {
+        refs.setFloating(node);
+        contentRef.current = node;
+      }}
+      style={floatingStyles}
+      className={clsx(
+        'border-gray100 bg-gray50 z-50 m-1 rounded-2xl border shadow-[0_1px_3px_1px_rgba(0,0,0,0.08),0_1px_5px_2px_rgba(0,0,0,0.02)]',
+        className
+      )}
+    >
+      {children(close)}
+    </div>,
+    document.body
+  );
 };
 
 export default PopoverContent;

--- a/src/components/basics/Popover/PopoverProvider.tsx
+++ b/src/components/basics/Popover/PopoverProvider.tsx
@@ -1,21 +1,13 @@
 'use client';
 
-import { useOutsideClick } from '@/hooks/util/useOutsideClickHandler';
 import { Placement } from '@floating-ui/react-dom';
-import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 
 import { PopoverContext } from './PopoverContext';
 
 const PopoverProvider = ({ children, placement }: PropsWithChildren<{ placement: Placement }>) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [activeKey, setActiveKey] = useState<string | null>(null);
-
-  const popoverRef = useRef<HTMLElement | null>(null);
-  const anchorRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    anchorRef.current = anchorEl;
-  }, [anchorEl]);
 
   const open = useCallback((key: string, anchor: HTMLElement) => {
     setActiveKey(key);
@@ -35,14 +27,6 @@ const PopoverProvider = ({ children, placement }: PropsWithChildren<{ placement:
     [activeKey, anchorEl, close, open]
   );
 
-  useOutsideClick(
-    [popoverRef, anchorRef],
-    () => {
-      close();
-    },
-    Boolean(activeKey)
-  );
-
   const value = useMemo(
     () => ({
       anchorEl,
@@ -51,7 +35,6 @@ const PopoverProvider = ({ children, placement }: PropsWithChildren<{ placement:
       open,
       close,
       toggle,
-      popoverRef,
     }),
     [anchorEl, activeKey, placement, open, close, toggle]
   );

--- a/src/components/basics/Popover/index.tsx
+++ b/src/components/basics/Popover/index.tsx
@@ -1,0 +1,5 @@
+import PopoverContent from './Content';
+import Popover from './Popover';
+import PopoverTrigger from './Trigger';
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/src/hooks/util/useOutsideClickHandler.tsx
+++ b/src/hooks/util/useOutsideClickHandler.tsx
@@ -23,13 +23,13 @@ export function useOutsideClick(
       const isInside = refs.some(ref => ref.current && ref.current.contains(target));
 
       if (!isInside) {
-        handler(event);
+        handlerRef.current(event);
       }
     };
 
-    document.addEventListener('mousedown', listener, true);
+    document.addEventListener('click', listener, true);
     return () => {
-      document.removeEventListener('mousedown', listener, true);
+      document.removeEventListener('click', listener, true);
     };
     // useRef로 handler의 최신 값을유지하므로 해당 useEffect에 의존성으로 넣을 필요 없음
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/stories/Popover.stories.tsx
+++ b/src/stories/Popover.stories.tsx
@@ -39,9 +39,19 @@ export const Default: StoryObj<typeof Popover> = {
           <IconButton icon="IC_AllLink" ariaLabel="아이콘버튼" />
         </PopoverTrigger>
         <PopoverContent popoverKey="trigger1">
-          <div className="cursor-pointer hover:bg-gray-50">Popover Content</div>
-          <div className="cursor-pointer hover:bg-gray-50">Popover Content</div>
-          <div className="cursor-pointer hover:bg-gray-50">Popover Content</div>
+          {close => (
+            <div
+              onClick={() => {
+                alert('Clicked!');
+                close();
+              }}
+            >
+              Popover Content with Close
+              <div className="cursor-pointer hover:bg-gray-50">Popover Content</div>
+              <div className="cursor-pointer hover:bg-gray-50">Popover Content</div>
+              <div className="cursor-pointer hover:bg-gray-50">Popover Content</div>
+            </div>
+          )}
         </PopoverContent>
       </Popover>
     </div>


### PR DESCRIPTION
## 관련 이슈

- close #316 

## PR 설명
- `useOutsideClick`을 `PopoverContent`에서 사용하도록 수정
- `useOutsideClickHandler`에서 `mousedown`을 `click`으로 수정
- `Popover/index.tsx`를 추가하여 import 용이하도록 수정