### PR TITLE
SideNavigation 메뉴 디자인 수정

### DIFF
--- a/src/components/layout/SideNavigation/components/NavItem/LinkNavItem.tsx
+++ b/src/components/layout/SideNavigation/components/NavItem/LinkNavItem.tsx
@@ -14,7 +14,7 @@ interface LinkNavItemProps extends Omit<
   ariaLabel: string; // LinkIconButton
 }
 
-const LinkNavItem = ({ children, href, icon, ariaLabel, ...props }: LinkNavItemProps) => {
+const LinkNavItem = ({ label, href, icon, ariaLabel, ...props }: LinkNavItemProps) => {
   const { isOpen } = useSideNavStore();
   const { ref, onClick } = useBlurOnClick(props.onClick);
 
@@ -31,12 +31,11 @@ const LinkNavItem = ({ children, href, icon, ariaLabel, ...props }: LinkNavItemP
       {...commonProps}
       icon={icon}
       radius="full"
-      className="flex h-10 w-50 justify-start gap-2 pl-2"
+      className="flex h-10! w-50 justify-start gap-2 pl-2"
       ref={ref}
+      label={label}
       onClick={onClick}
-    >
-      {children}
-    </LinkButton>
+    />
   ) : (
     <LinkIconButton
       {...commonProps}

--- a/src/components/layout/SideNavigation/components/NavItem/NavItem.tsx
+++ b/src/components/layout/SideNavigation/components/NavItem/NavItem.tsx
@@ -9,7 +9,7 @@ interface NavItemProps extends Omit<ButtonProps, 'variant' | 'contextStyle' | 'r
   ariaLabel: string;
 }
 
-const NavItem = ({ children, icon, ariaLabel, ...props }: NavItemProps) => {
+const NavItem = ({ label, icon, ariaLabel, ...props }: NavItemProps) => {
   const { isOpen } = useSideNavStore();
   const { ref, onClick } = useBlurOnClick(props.onClick);
 
@@ -24,12 +24,11 @@ const NavItem = ({ children, icon, ariaLabel, ...props }: NavItemProps) => {
       {...commonProps}
       icon={icon}
       radius="full"
-      className="flex h-10 w-50 justify-start gap-2 pl-2"
+      className="flex h-10! w-50 justify-start gap-2 pl-2"
       ref={ref}
+      label={label}
       onClick={onClick}
-    >
-      {children}
-    </Button>
+    />
   ) : (
     <IconButton {...commonProps} icon={icon} ariaLabel={ariaLabel!} ref={ref} onClick={onClick} />
   );


### PR DESCRIPTION
## 관련 이슈

- close #322

## PR 설명
- SideNavigation의 메뉴 아이템 디자인 수정
- `children` props를 `label`로 수정