### PR TITLE
링크추가 모달 API 연결

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -5,6 +5,9 @@ import type {
   LinkApiResponse,
   LinkListApiResponse,
   LinkListViewData,
+  LinkMetaScrapeApiResponse,
+  LinkSummaryFormat,
+  LinkSummaryRegenerateApiResponse,
 } from '@/types/api/linkApi';
 import type { CreateLinkPayload, Link, UpdateLinkPayload } from '@/types/link';
 
@@ -193,4 +196,35 @@ export const checkDuplicateLink = async (
   }
 
   return { exists: body.data.exists, linkId: body.data.linkId };
+};
+
+export const scrapeLinkMeta = async (url: string) => {
+  const body = await safeFetch<LinkMetaScrapeApiResponse>(
+    `${LINKS_ENDPOINT}/meta-scrape`,
+    withAuth({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    })
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return body.data;
+};
+
+export const regenerateLinkSummary = async (id: number, format: LinkSummaryFormat) => {
+  const usp = new URLSearchParams({ format });
+  const body = await safeFetch<LinkSummaryRegenerateApiResponse>(
+    `${LINKS_ENDPOINT}/${id}/summary?${usp.toString()}`,
+    withAuth({ cache: 'no-store' })
+  );
+
+  if (!body?.data || !body.success) {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return body.data;
 };

--- a/src/components/basics/Toast/ToastContainer.tsx
+++ b/src/components/basics/Toast/ToastContainer.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/toastStore';
+import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -8,6 +10,7 @@ import Toast from './Toast';
 
 const ToastContainer = () => {
   const { toasts, hideToast } = useToastStore();
+  const modalType = useModalStore(state => state.type);
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -25,9 +28,18 @@ const ToastContainer = () => {
 
   if (!portalElement || toasts.length === 0) return null;
 
+  const isModalOpen = modalType !== null;
+  const hasModalPlacementToast = toasts.some(toast => toast.placement === 'modal-bottom');
+  const useModalLayout = isModalOpen || hasModalPlacementToast;
+
   return createPortal(
-    <div className="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end gap-3 px-4 pt-6">
-      <div className="flex flex-col items-end gap-3">
+    <div
+      className={clsx(
+        'pointer-events-none fixed inset-0 z-[60] flex flex-col gap-3 px-4',
+        useModalLayout ? 'items-center justify-end pb-[7.5rem]' : 'items-end pt-6'
+      )}
+    >
+      <div className={clsx('flex flex-col gap-3', useModalLayout ? 'items-center' : 'items-end')}>
         {toasts.map(toast => (
           <Toast key={toast.id} {...toast} onClose={hideToast} />
         ))}

--- a/src/components/layout/SideNavigation/components/MenuSection/AddLinkModal.tsx
+++ b/src/components/layout/SideNavigation/components/MenuSection/AddLinkModal.tsx
@@ -3,18 +3,29 @@
 import Button from '@/components/basics/Button/Button';
 import Label from '@/components/basics/Label/Label';
 import Modal from '@/components/basics/Modal/Modal';
+import Skeleton from '@/components/basics/Skeleton/Skeleton';
+import Spinner from '@/components/basics/Spinner/Spinner';
 import TextArea from '@/components/basics/TextArea/TextArea';
+import { useLinkMetaScrape } from '@/hooks/useLinkMetaScrape';
+import { usePostLinks } from '@/hooks/usePostLinks';
+import { useLinkStore } from '@/stores/linkStore';
 import { useModalStore } from '@/stores/modalStore';
+import { hideToast, showToast } from '@/stores/toastStore';
 import { zodResolver } from '@hookform/resolvers/zod';
+import clsx from 'clsx';
 import Image from 'next/image';
-import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 
 import AddLinkUrlInput from './AddLinkUrlInput';
 
 const addLinkSchema = z.object({
-  url: z.string().url({ message: '유효하지 않은 링크 주소입니다. URL을 다시 확인해주세요.' }),
+  url: z
+    .string()
+    .trim()
+    .url({ message: '유효하지 않은 링크 주소입니다. URL을 다시 확인해 주세요.' }),
   title: z.string().min(1, { message: '제목을 입력해 주세요.' }),
   memo: z.string().optional(),
 });
@@ -22,25 +33,142 @@ type AddLinkForm = z.infer<typeof addLinkSchema>;
 
 const AddLinkModal = () => {
   const { close } = useModalStore();
-  const [imageUrl] = useState('/file.svg');
+  const createLink = usePostLinks();
+  const lastSubmitErrorRef = useRef<Error | null>(null);
+  const lastSubmitPayloadRef = useRef<{
+    url: string;
+    title: string;
+    memo?: string;
+    imageUrl?: string;
+  } | null>(null);
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+  const router = useRouter();
+  const selectLink = useLinkStore(state => state.selectLink);
 
   const {
     control,
     handleSubmit,
-    formState: { errors, isValid },
+    setValue,
+    getValues,
+    formState: { errors, isValid, dirtyFields },
   } = useForm<AddLinkForm>({
     resolver: zodResolver(addLinkSchema),
     defaultValues: { url: '', title: '', memo: '' },
     mode: 'all',
   });
+  const urlValue = useWatch({ control, name: 'url' });
+  const titleValue = useWatch({ control, name: 'title' });
+  const memoValue = useWatch({ control, name: 'memo' });
+  const trimmedUrl = useMemo(() => urlValue?.trim() ?? '', [urlValue]);
+  const isValidUrl = useMemo(() => z.string().url().safeParse(trimmedUrl).success, [trimmedUrl]);
+  const lastInputsRef = useRef({ trimmedUrl, titleValue, memoValue });
+  const { metaData, metaLoading, metaErrorMessage } = useLinkMetaScrape<AddLinkForm>({
+    url: trimmedUrl,
+    isValidUrl,
+    dirtyFields,
+    getValues,
+    setValue,
+  });
+  const shouldDisableDetails = !trimmedUrl || !isValidUrl || metaLoading;
+  const previewImageUrl = metaData?.image?.trim()
+    ? metaData.image
+    : '/images/default_linkcard_image.png';
 
-  const onSubmit = (data: AddLinkForm) => {
-    console.log(data);
-    close();
+  const handleCreateSuccess = useCallback(
+    (createdLink: { id: number }) => {
+      const toastId = showToast({
+        message: '링크가 저장되었습니다. 요약 생성을 시작합니다.',
+        variant: 'success',
+        showIcon: true,
+        placement: 'modal-bottom',
+        actionLabel: '요약 확인',
+        actionLabelIcon: 'IC_AllLink',
+        onAction: () => {
+          hideToast(toastId);
+          selectLink(createdLink.id);
+          router.push('/all-link');
+        },
+      });
+      close();
+    },
+    [close, router, selectLink]
+  );
+
+  const handleRetry = useCallback(
+    async (toastId: string) => {
+      const payload = lastSubmitPayloadRef.current;
+      if (!payload) return;
+      hideToast(toastId);
+      lastSubmitErrorRef.current = null;
+      try {
+        const createdLink = await createLink.mutateAsync(payload);
+        handleCreateSuccess(createdLink);
+      } catch {
+        // handled by createLink error state
+      }
+    },
+    [createLink, handleCreateSuccess]
+  );
+
+  useEffect(() => {
+    const lastInputs = lastInputsRef.current;
+    const inputsChanged =
+      lastInputs.trimmedUrl !== trimmedUrl ||
+      lastInputs.titleValue !== titleValue ||
+      lastInputs.memoValue !== memoValue;
+    if (!inputsChanged) return;
+    lastInputsRef.current = { trimmedUrl, titleValue, memoValue };
+    setHasSubmitError(false);
+    if (createLink.isError) {
+      createLink.reset();
+      lastSubmitErrorRef.current = null;
+    }
+  }, [trimmedUrl, titleValue, memoValue, createLink]);
+
+  useEffect(() => {
+    if (!createLink.isError || !createLink.error) return;
+    if (lastSubmitErrorRef.current === createLink.error) return;
+    lastSubmitErrorRef.current = createLink.error;
+    setHasSubmitError(true);
+    const toastId = showToast({
+      message: '링크를 저장하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      variant: 'error',
+      showIcon: true,
+      placement: 'modal-bottom',
+      actionLabel: '다시 시도',
+      actionLabelIcon: 'IC_Regenerate',
+      onAction: () => {
+        handleRetry(toastId);
+      },
+    });
+  }, [createLink.isError, createLink.error, handleRetry]);
+
+  const onSubmit = async (data: AddLinkForm) => {
+    const trimmedMemo = data.memo?.trim();
+    const trimmedImageUrl = metaData?.image?.trim();
+
+    lastSubmitPayloadRef.current = {
+      url: data.url,
+      title: data.title,
+      memo: trimmedMemo || undefined,
+      imageUrl: trimmedImageUrl || undefined,
+    };
+    try {
+      const createdLink = await createLink.mutateAsync(lastSubmitPayloadRef.current);
+      handleCreateSuccess(createdLink);
+    } catch {
+      // handled by createLink error state
+    }
   };
 
   return (
-    <Modal type="ADD_LINK" className="m-10 min-w-150">
+    <Modal
+      type="ADD_LINK"
+      className={clsx(
+        'm-10 min-w-150 rounded-[0.625rem] border',
+        hasSubmitError ? 'border-red500' : 'border-transparent'
+      )}
+    >
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <Label htmlFor="url-input">링크 주소</Label>
@@ -51,19 +179,34 @@ const AddLinkModal = () => {
               <AddLinkUrlInput
                 {...field}
                 id="url-input"
-                placeholder="URL을 입력해 주세요"
+                placeholder="URL을 입력해 주세요."
                 onChange={field.onChange}
                 errorMessage={errors.url?.message}
               />
             )}
           />
+          {metaErrorMessage && <span className="text-red500 text-xs">{metaErrorMessage}</span>}
         </div>
         <div className="flex flex-col gap-1">
           <div className="flex gap-2">
             <div className="flex flex-1 flex-col">
               <Label>썸네일</Label>
-              <div className="relative h-23 rounded-lg bg-white">
-                <Image src={imageUrl} alt="link thumbnail" fill />
+              <div
+                className={`relative h-[4.2rem] w-full rounded-lg bg-white ${
+                  shouldDisableDetails ? 'opacity-60' : ''
+                }`}
+                aria-disabled={shouldDisableDetails}
+              >
+                {metaLoading && isValidUrl ? (
+                  <>
+                    <Skeleton className="h-full w-full" radius="lg" animated />
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <Spinner size="lg" />
+                    </div>
+                  </>
+                ) : (
+                  <Image src={previewImageUrl} alt="link thumbnail" fill />
+                )}
               </div>
             </div>
             <div className="flex flex-3 flex-col">
@@ -74,18 +217,22 @@ const AddLinkModal = () => {
                 render={({ field }) => (
                   <TextArea
                     {...field}
-                    placeholder="제목을 입력해 주세요"
+                    placeholder="제목을 입력해 주세요."
                     id="title-input"
                     radius="lg"
                     heightLines={2}
                     maxHeightLines={2}
                     maxLength={100}
+                    isLoading={metaLoading && isValidUrl}
+                    disabled={shouldDisableDetails}
                     value={field.value ?? ''}
                     onChange={e => field.onChange(e)}
                   />
                 )}
               />
-              {errors.title && <span className="text-red500 text-xs">{errors.title.message}</span>}
+              {errors.title && !shouldDisableDetails && (
+                <span className="text-red500 text-xs">{errors.title.message}</span>
+              )}
             </div>
           </div>
         </div>
@@ -98,18 +245,24 @@ const AddLinkModal = () => {
               <TextArea
                 {...field}
                 id="memo-input"
-                placeholder="메모를 입력해 주세요"
+                placeholder="메모를 입력해 주세요."
                 radius="lg"
                 heightLines={3}
                 maxHeightLines={3}
                 maxLength={600}
+                isLoading={metaLoading && isValidUrl}
+                disabled={shouldDisableDetails}
                 value={field.value ?? ''}
                 onChange={e => field.onChange(e)}
               />
             )}
           />
         </div>
-        <Button type="submit" label="제출하기" disabled={!isValid} />
+        <Button
+          type="submit"
+          label={createLink.isPending ? '저장 중...' : '저장하기'}
+          disabled={!isValid || metaLoading || createLink.isPending}
+        />
       </form>
     </Modal>
   );

--- a/src/hooks/useLinkMetaScrape.ts
+++ b/src/hooks/useLinkMetaScrape.ts
@@ -1,0 +1,135 @@
+import { usePostLinkMetaScrape } from '@/hooks/usePostLinkMetaScrape';
+import { FetchError } from '@/hooks/util/server/safeFetch';
+import { useEffect, useRef, useState } from 'react';
+import type {
+  FieldValues,
+  Path,
+  PathValue,
+  UseFormGetValues,
+  UseFormSetValue,
+} from 'react-hook-form';
+
+type MetaData = {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+};
+
+type LinkMetaScrapeOptions<T extends FieldValues & { title?: string; memo?: string }> = {
+  url: string;
+  isValidUrl: boolean;
+  dirtyFields: Partial<Record<keyof T, boolean>>;
+  getValues: UseFormGetValues<T>;
+  setValue: UseFormSetValue<T>;
+};
+
+export function useLinkMetaScrape<T extends FieldValues & { title?: string; memo?: string }>({
+  url,
+  isValidUrl,
+  dirtyFields,
+  getValues,
+  setValue,
+}: LinkMetaScrapeOptions<T>) {
+  const metaScrape = usePostLinkMetaScrape();
+  const [metaData, setMetaData] = useState<MetaData | null>(null);
+  const [metaLoading, setMetaLoading] = useState(false);
+  const [metaErrorMessage, setMetaErrorMessage] = useState<string | null>(null);
+  const lastScrapedUrl = useRef<string | null>(null);
+  const metaRequestId = useRef(0);
+  const titlePath = 'title' as Path<T>;
+  const memoPath = 'memo' as Path<T>;
+
+  useEffect(() => {
+    if (!url || !isValidUrl) {
+      metaRequestId.current += 1;
+      if (metaScrape.status !== 'idle') {
+        metaScrape.reset();
+      }
+      if (metaLoading) {
+        setMetaLoading(false);
+      }
+      if (metaData !== null) {
+        setMetaData(null);
+      }
+      if (metaErrorMessage) {
+        setMetaErrorMessage(null);
+      }
+      if (!dirtyFields.title && getValues(titlePath)) {
+        setValue(titlePath, '' as PathValue<T, typeof titlePath>, { shouldValidate: true });
+      }
+      if (!dirtyFields.memo && getValues(memoPath)) {
+        setValue(memoPath, '' as PathValue<T, typeof memoPath>, { shouldValidate: true });
+      }
+      lastScrapedUrl.current = null;
+      return;
+    }
+
+    if (url === lastScrapedUrl.current) return;
+
+    if (metaData !== null) {
+      setMetaData(null);
+    }
+    if (metaErrorMessage) {
+      setMetaErrorMessage(null);
+    }
+    if (!dirtyFields.title && getValues(titlePath)) {
+      setValue(titlePath, '' as PathValue<T, typeof titlePath>, { shouldValidate: true });
+    }
+    if (!dirtyFields.memo && getValues(memoPath)) {
+      setValue(memoPath, '' as PathValue<T, typeof memoPath>, { shouldValidate: true });
+    }
+    metaRequestId.current += 1;
+    const requestId = metaRequestId.current;
+    lastScrapedUrl.current = url;
+    if (!metaLoading) {
+      setMetaLoading(true);
+    }
+    const timeoutId = setTimeout(() => {
+      metaScrape
+        .mutateAsync(url)
+        .then(data => {
+          if (requestId !== metaRequestId.current) return;
+          setMetaData(data);
+          setMetaLoading(false);
+          if (!dirtyFields.title) {
+            setValue(titlePath, (data.title ?? '') as PathValue<T, typeof titlePath>, {
+              shouldValidate: true,
+            });
+          }
+          if (!dirtyFields.memo) {
+            setValue(memoPath, (data.description ?? '') as PathValue<T, typeof memoPath>, {
+              shouldValidate: true,
+            });
+          }
+        })
+        .catch(error => {
+          if (requestId !== metaRequestId.current) return;
+          if (process.env.NODE_ENV !== 'production') {
+            console.error('[meta-scrape] failed', error);
+          }
+          if (error instanceof FetchError) {
+            setMetaErrorMessage(
+              `메타 정보를 가져오지 못했습니다. (status: ${error.status ?? 'unknown'})`
+            );
+          }
+          setMetaLoading(false);
+        });
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [
+    url,
+    isValidUrl,
+    metaScrape,
+    metaData,
+    metaLoading,
+    metaErrorMessage,
+    setValue,
+    getValues,
+    dirtyFields.title,
+    dirtyFields.memo,
+  ]);
+
+  return { metaData, metaLoading, metaErrorMessage };
+}

--- a/src/hooks/usePostLinkMetaScrape.ts
+++ b/src/hooks/usePostLinkMetaScrape.ts
@@ -1,0 +1,9 @@
+import { scrapeLinkMeta } from '@/apis/linkApi';
+import type { LinkMetaScrapeData } from '@/types/api/linkApi';
+import { useMutation } from '@tanstack/react-query';
+
+export function usePostLinkMetaScrape() {
+  return useMutation<LinkMetaScrapeData, Error, string>({
+    mutationFn: scrapeLinkMeta,
+  });
+}

--- a/src/hooks/useRegenerateLinkSummary.ts
+++ b/src/hooks/useRegenerateLinkSummary.ts
@@ -1,0 +1,14 @@
+import { regenerateLinkSummary } from '@/apis/linkApi';
+import type { LinkSummaryFormat, LinkSummaryRegenerateData } from '@/types/api/linkApi';
+import { useMutation } from '@tanstack/react-query';
+
+type SummaryParams = {
+  id: number;
+  format: LinkSummaryFormat;
+};
+
+export function useRegenerateLinkSummary() {
+  return useMutation<LinkSummaryRegenerateData, Error, SummaryParams>({
+    mutationFn: ({ id, format }) => regenerateLinkSummary(id, format),
+  });
+}

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -12,6 +12,7 @@ export interface ToastItem {
   actionLabel?: string;
   actionLabelIcon?: IconMapTypes;
   onAction?: () => void;
+  placement?: 'modal-bottom';
 }
 
 interface ToastStore {

--- a/src/types/api/linkApi.ts
+++ b/src/types/api/linkApi.ts
@@ -47,3 +47,22 @@ export type DuplicateLinkApiResponse = ApiResponseBase<{
   exists: boolean;
   linkId?: number;
 }>;
+
+export interface LinkMetaScrapeData {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}
+
+export type LinkMetaScrapeApiResponse = ApiResponseBase<LinkMetaScrapeData>;
+
+export type LinkSummaryFormat = 'CONCISE' | 'DETAILED';
+
+export interface LinkSummaryRegenerateData {
+  existingSummary: string;
+  newSummary: string;
+  comparison: string;
+}
+
+export type LinkSummaryRegenerateApiResponse = ApiResponseBase<LinkSummaryRegenerateData>;


### PR DESCRIPTION
## 관련 이슈

- close #340

## PR 설명

- src/apis/linkApi.ts
  - 메타 스크랩(`/v1/links/meta-scrape`) 및 요약 재생성(`/v1/links/{id}/summary`) API 추가
- src/types/api/linkApi.ts
  - 메타 스크랩/요약 재생성 응답 타입 및 포맷 타입 추가
- src/hooks/usePostLinkMetaScrape.ts
  - 메타 스크랩 요청용 React Query mutation 훅 추가
- src/hooks/useRegenerateLinkSummary.ts
  - 요약 재생성 요청용 React Query mutation 훅 추가
- src/app/layout-client.tsx
  - ReactQueryProvider를 레이아웃 최상위로 이동해 SideNavigation 포함 범위에서 사용 가능하게 변경
- src/components/layout/SideNavigation/components/AddLinkModal.tsx
  - URL 입력 시 메타 조회 및 스켈레톤/스피너 표시
  - 유효하지 않은 링크/입력 전 상태에서는 상세 입력/버튼 비활성화
  - 저장하기 클릭 시 링크 생성 API 호출 및 로딩/실패 UI 처리
  - 썸네일 높이를 제목 영역과 맞춤

현재 API 오류로 정상화 되면 다시 확인하고 리뷰받겠습니다.