### PR TITLE
상세정보 패널 디자인 수정 및 섹션 분리

### DIFF
--- a/src/app/(dev)/mock-chat/MockChatPage.tsx
+++ b/src/app/(dev)/mock-chat/MockChatPage.tsx
@@ -149,6 +149,7 @@ export default function MockChatPage() {
       {selectedLink && (
         <aside className="border-gray200 hidden h-screen shrink-0 border-l xl:block xl:w-130">
           <LinkCardDetailPanel
+            id={selectedLink.linkId}
             url={selectedLink.url}
             title={selectedLink.title}
             summary={selectedLink.summary ?? ''}

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -81,6 +81,7 @@ export default function AllLink() {
           <aside className="hidden h-screen shrink-0 xl:block xl:w-130">
             {selectedLink ? (
               <LinkCardDetailPanel
+                id={selectedLink.id}
                 url={selectedLink.url}
                 title={selectedLink.title}
                 summary={selectedLink.summary ?? ''}

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -356,6 +356,7 @@ export default function Chat() {
       {selectedLink && (
         <aside className="border-gray200 hidden h-screen shrink-0 border-l xl:block xl:w-130">
           <LinkCardDetailPanel
+            id={selectedLink.linkId}
             url={selectedLink.url}
             title={selectedLink.title}
             summary={selectedLink.summary ?? ''}

--- a/src/components/basics/Anchor/Anchor.style.ts
+++ b/src/components/basics/Anchor/Anchor.style.ts
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 export const style = tv({
-  base: 'text-anchor flex items-center gap-1 hover:underline [&>svg]:text-inherit [&>svg]:transition-colors [&>svg]:duration-150 [&>svg]:ease-in-out',
+  base: 'text-anchor flex items-center gap-1 hover:underline [&>svg]:shrink-0 [&>svg]:text-inherit [&>svg]:transition-colors [&>svg]:duration-150 [&>svg]:ease-in-out',
   variants: {
     size: {
       sm: 'font-anchor-sm',

--- a/src/components/basics/Modal/Modal.tsx
+++ b/src/components/basics/Modal/Modal.tsx
@@ -24,7 +24,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
   { className, children, type, ...rest },
   ref
 ) {
-  const { type: openType, close } = useModalStore();
+  const { modal, close } = useModalStore();
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
 
   // 포털 렌더링을 위한 div 체크
@@ -40,7 +40,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
     }
   }, []);
 
-  if (openType !== type) return null;
+  if (modal.type !== type) return null;
   if (!portalElement) return null;
 
   return createPortal(

--- a/src/components/basics/TextArea/TextArea.tsx
+++ b/src/components/basics/TextArea/TextArea.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { textAreaStyle, wholeBoxStyle } from './TextArea.style';
 import { useAutoResizeTextArea } from './hooks/useAutoResizeTextArea';
 
-const LINE_HEIGHTS = { sm: 19, md: 26, lg: 29 };
+export const LINE_HEIGHTS = { sm: 19, md: 26, lg: 29 };
 export interface TextAreaProps extends Omit<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
   'value' | 'onChange' | 'onSubmit'

--- a/src/components/basics/Tooltip/Tooltip.tsx
+++ b/src/components/basics/Tooltip/Tooltip.tsx
@@ -92,7 +92,7 @@ const Tooltip = React.forwardRef<HTMLSpanElement, TooltipProps>(function Tooltip
   return (
     <span
       ref={ref}
-      className="relative inline-flex"
+      className="relative flex"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onFocus={handleFocus}

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/ChatItem.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/ChatItem.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const ChatItem = ({ id, label }: Props) => {
   const router = useRouter();
-  const { open } = useModalStore();
+  const open = useModalStore(state => state.open);
 
   const handleItemClick = () => {
     router.push(`/chat/${id}`);

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/ChatRoomSection.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/ChatRoomSection.tsx
@@ -8,7 +8,7 @@ import DeleteChatModal from './DeleteChatModal';
 
 const ChatRoomSection = () => {
   const { data: chats = [], isLoading, isError } = useChatList();
-  const { type, props } = useModalStore();
+  const { modal } = useModalStore();
 
   return (
     <>
@@ -27,11 +27,9 @@ const ChatRoomSection = () => {
         </div>
       </div>
 
-      {type === 'DELETE_CHAT' &&
-        typeof props?.chatId === 'number' &&
-        typeof props?.title === 'string' && (
-          <DeleteChatModal chatId={props.chatId} title={props.title} />
-        )}
+      {modal.type === 'DELETE_CHAT' && (
+        <DeleteChatModal chatId={modal.props.chatId} title={modal.props.title} />
+      )}
     </>
   );
 };

--- a/src/components/layout/SideNavigation/components/MenuSection/AddLink/AddLinkUrlInput.tsx
+++ b/src/components/layout/SideNavigation/components/MenuSection/AddLink/AddLinkUrlInput.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import IconButton from '@/components/basics/IconButton/IconButton';
 import TextArea, { type TextAreaProps } from '@/components/basics/TextArea/TextArea';
-import Tooltip from '@/components/basics/Tooltip/Tooltip';
-import { showToast } from '@/stores/toastStore';
+import CopyButton from '@/components/wrappers/CopyButton';
 import clsx from 'clsx';
 import React from 'react';
 
@@ -44,25 +42,6 @@ const AddLinkUrlInput = React.forwardRef<HTMLTextAreaElement, AddLinkUrlInputPro
     const inputId = id ?? name ?? 'add-link-url-input';
     const errorId = hasError ? `${inputId}-error` : undefined;
 
-    const handleCopyClick = async () => {
-      if (!trimmedValue) return;
-      if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) return;
-      try {
-        await navigator.clipboard.writeText(trimmedValue);
-        showToast({
-          message: '링크가 클립보드에 복사되었습니다.',
-          variant: 'success',
-          showIcon: true,
-        });
-      } catch {
-        showToast({
-          message: '링크 복사에 실패했습니다.',
-          variant: 'error',
-          showIcon: true,
-        });
-      }
-    };
-
     const handleKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = e => {
       if (e.key === 'Enter') {
         e.preventDefault();
@@ -98,18 +77,12 @@ const AddLinkUrlInput = React.forwardRef<HTMLTextAreaElement, AddLinkUrlInputPro
             {...rest}
           />
           <div className="absolute inset-y-0 right-2 flex items-center">
-            <Tooltip content="URL 복사하기" side="bottom">
-              <IconButton
-                icon="IC_Copy"
-                size="sm"
-                variant="tertiary_subtle"
-                contextStyle="onMain"
-                ariaLabel="URL 복사하기"
-                disabled={!trimmedValue}
-                className="pointer-events-auto"
-                onClick={handleCopyClick}
-              />
-            </Tooltip>
+            <CopyButton
+              value={trimmedValue}
+              successMsg="링크가 클립보드에 복사되었습니다."
+              failMsg="링크 복사에 실패했습니다."
+              tooltipMsg="링크 복사하기"
+            />
           </div>
         </div>
         {hasError && (

--- a/src/components/layout/SideNavigation/components/MenuSection/AddLinkModal.tsx
+++ b/src/components/layout/SideNavigation/components/MenuSection/AddLinkModal.tsx
@@ -8,6 +8,7 @@ import Spinner from '@/components/basics/Spinner/Spinner';
 import TextArea from '@/components/basics/TextArea/TextArea';
 import { useLinkMetaScrape } from '@/hooks/useLinkMetaScrape';
 import { usePostLinks } from '@/hooks/usePostLinks';
+import { MAX_MEMO_LENGTH, MAX_TITLE_LENGTH } from '@/lib/constants/link';
 import { useLinkStore } from '@/stores/linkStore';
 import { useModalStore } from '@/stores/modalStore';
 import { hideToast, showToast } from '@/stores/toastStore';
@@ -26,8 +27,14 @@ const addLinkSchema = z.object({
     .string()
     .trim()
     .url({ message: '유효하지 않은 링크 주소입니다. URL을 다시 확인해 주세요.' }),
-  title: z.string().min(1, { message: '제목을 입력해 주세요.' }),
-  memo: z.string().optional(),
+  title: z
+    .string()
+    .min(1, { message: '제목을 입력해 주세요.' })
+    .max(MAX_TITLE_LENGTH, { message: `제목은 ${MAX_TITLE_LENGTH}자 이하로 입력해 주세요.` }),
+  memo: z
+    .string()
+    .max(MAX_MEMO_LENGTH, { message: `메모는 ${MAX_MEMO_LENGTH}자 이하로 입력해 주세요.` })
+    .optional(),
 });
 type AddLinkForm = z.infer<typeof addLinkSchema>;
 
@@ -223,7 +230,7 @@ const AddLinkModal = () => {
                     radius="lg"
                     heightLines={2}
                     maxHeightLines={2}
-                    maxLength={100}
+                    maxLength={MAX_TITLE_LENGTH}
                     isLoading={metaLoading && isValidUrl}
                     disabled={shouldDisableDetails}
                     value={field.value ?? ''}
@@ -250,7 +257,7 @@ const AddLinkModal = () => {
                 radius="lg"
                 heightLines={3}
                 maxHeightLines={3}
-                maxLength={600}
+                maxLength={MAX_MEMO_LENGTH}
                 isLoading={metaLoading && isValidUrl}
                 disabled={shouldDisableDetails}
                 value={field.value ?? ''}

--- a/src/components/layout/SideNavigation/components/MenuSection/MenuSection.tsx
+++ b/src/components/layout/SideNavigation/components/MenuSection/MenuSection.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const MenuSection = ({ isOpen }: Props) => {
-  const { type, open } = useModalStore();
+  const { modal, open } = useModalStore();
 
   const MENU_ITEMS = [
     { id: 'new-chat', item: <NewChatButton /> },
@@ -39,7 +39,7 @@ const MenuSection = ({ isOpen }: Props) => {
           </div>
         ))}
       </nav>
-      {type === 'ADD_LINK' && <AddLinkModal />}
+      {modal.type === 'ADD_LINK' && <AddLinkModal />}
     </>
   );
 };

--- a/src/components/wrappers/CopyButton.tsx
+++ b/src/components/wrappers/CopyButton.tsx
@@ -1,0 +1,73 @@
+import { showToast } from '@/stores/toastStore';
+
+import IconButton, { IconButtonProps } from '../basics/IconButton/IconButton';
+import Tooltip from '../basics/Tooltip/Tooltip';
+
+interface CopyButtonProps extends Omit<IconButtonProps, 'ariaLabel' | 'icon'> {
+  value: string;
+  successMsg: string;
+  failMsg: string;
+  tooltipMsg: string;
+  tooltipClassName?: string;
+}
+
+export default function CopyButton({
+  value,
+  size = 'sm',
+  variant = 'tertiary_subtle',
+  contextStyle = 'onMain',
+  successMsg,
+  failMsg,
+  tooltipMsg,
+  className,
+  tooltipClassName,
+  disabled,
+  onClick,
+  ...iconButtonProps
+}: CopyButtonProps) {
+  const isClipboardSupported =
+    typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.writeText);
+  const isDisabled = Boolean(disabled) || !value || !isClipboardSupported;
+
+  const handleCopyClick: NonNullable<IconButtonProps['onClick']> = async event => {
+    onClick?.(event);
+    if (isDisabled) {
+      showToast({
+        message: failMsg,
+        variant: 'error',
+        showIcon: true,
+      });
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      showToast({
+        message: successMsg,
+        variant: 'success',
+        showIcon: true,
+      });
+    } catch {
+      showToast({
+        message: failMsg,
+        variant: 'error',
+        showIcon: true,
+      });
+    }
+  };
+
+  return (
+    <Tooltip content={tooltipMsg} side="bottom" className={tooltipClassName}>
+      <IconButton
+        icon="IC_Copy"
+        size={size}
+        variant={variant}
+        contextStyle={contextStyle}
+        ariaLabel={tooltipMsg}
+        disabled={isDisabled}
+        className={`pointer-events-auto ${className ?? ''}`}
+        onClick={handleCopyClick}
+        {...iconButtonProps}
+      />
+    </Tooltip>
+  );
+}

--- a/src/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.style.ts
+++ b/src/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.style.ts
@@ -5,16 +5,12 @@ export const styles = tv({
     root: 'bg-gray50 custom-scrollbar h-screen w-[520px] overflow-x-hidden overflow-y-auto pt-2 pr-1',
     content: 'flex h-full flex-col gap-0 pb-6',
     header: 'flex items-center justify-between px-5 py-3',
-    headerLeft: 'flex items-center gap-2',
-    headerBadge: 'bg-gray900 flex h-4 w-4 items-center justify-center rounded-full',
-    divider: 'mx-0 my-2',
     section: 'flex flex-col gap-2 px-5 pt-5 pb-4',
-    titleCard: 'rounded-md bg-white p-3 shadow-sm',
+    titleCard:
+      'custom-scrollbar border-gray100 line-clamp-2 w-full overflow-y-auto rounded-md border bg-white p-3',
     actionRow: 'flex items-center gap-2',
-    linkActions: 'flex items-center gap-2 pt-1',
-    imageWrapper:
-      'border-gray100 relative h-[220px] w-full overflow-hidden border bg-white shadow-sm',
+    linkActions: 'flex justify-end',
+    imageWrapper: 'border-gray100 relative h-[220px] w-full overflow-hidden border bg-white',
     summaryWrapper: 'flex flex-col gap-2',
-    memoWrapper: 'w-full',
   },
 });

--- a/src/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.tsx
@@ -1,493 +1,80 @@
 'use client';
 
-import SVGIcon from '@/components/Icons/SVGIcon';
-import AccordionButton from '@/components/basics/Accordion/AccordionButton/AccordionButton';
-import Anchor from '@/components/basics/Anchor/Anchor';
-import Button from '@/components/basics/Button/Button';
-import Divider from '@/components/basics/Divider/Divider';
-import IconButton from '@/components/basics/IconButton/IconButton';
-import Label from '@/components/basics/Label/Label';
-import ProgressNotification from '@/components/basics/ProgressNotification/ProgressNotification';
-import TextArea from '@/components/basics/TextArea/TextArea';
-import Tooltip from '@/components/basics/Tooltip/Tooltip';
 import { styles } from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.style';
-import TitleTextArea from '@/components/wrappers/LinkCardDetailPanel/TitleTextArea';
 import { getSafeUrl } from '@/hooks/util/getSafeUrl';
-import Image from 'next/image';
-import React, { useEffect, useRef, useState } from 'react';
+import { useModalStore } from '@/stores/modalStore';
 
-type ActionNodes = React.ReactNode | null;
+import ReSummaryModal from '../ReSummaryModal/ReSummaryModal';
+import HeaderSection from './Sections/HeaderSection';
+import ImageSection from './Sections/ImageSection';
+import MemoSection from './Sections/MemoSection';
+import SummarySection from './Sections/SummarySection';
+import TitleSection from './Sections/TitleSection';
 
-type SummaryState = 'idle' | 'loading' | 'writing' | 'error' | 'ready';
+export type SummaryState = 'idle' | 'loading' | 'writing' | 'error' | 'ready';
 
 interface LinkCardDetailPanelProps {
+  id: number;
   url: string;
   title: string;
   summary: string;
   memo?: string;
   imageUrl?: string;
-  headerActions?: ActionNodes;
-  titleActions?: ActionNodes;
-  summaryActions?: ActionNodes;
-  memoActions?: ActionNodes;
   memoEditable?: boolean;
   summaryState?: SummaryState;
   summaryErrorMessage?: string;
   onClose?: () => void;
-  onMore?: () => void;
   onTitleChange?: (value: string) => void;
   onMemoChange?: (value: string) => void;
-  onRegenerateSummary?: () => void;
   onRetrySummary?: () => void;
 }
 
-const TITLE_MAX_LENGTH = 100;
-const MEMO_MAX_LENGTH = 200;
-
 const LinkCardDetailPanel = ({
+  id,
   url,
   title,
   summary,
   memo = '',
   imageUrl,
-  headerActions,
-  titleActions,
-  summaryActions,
-  memoActions,
   memoEditable = true,
   summaryState: summaryStateProp = 'idle',
   summaryErrorMessage,
   onClose,
-  onMore,
   onTitleChange,
   onMemoChange,
-  onRegenerateSummary,
   onRetrySummary,
 }: LinkCardDetailPanelProps) => {
   const safeUrl = getSafeUrl(url);
-  const memoAreaRef = useRef<HTMLTextAreaElement>(null);
-  const titleAreaRef = useRef<HTMLTextAreaElement>(null);
-  const summaryRef = useRef<HTMLParagraphElement>(null);
-  const isInteractiveSummary =
-    summaryStateProp === 'ready' || summaryStateProp === 'idle' || summaryStateProp === 'writing';
-  const [internalTitle, setInternalTitle] = useState(title);
-  const [internalMemo, setInternalMemo] = useState(memo);
-  const [isTitleEditing, setIsTitleEditing] = useState(false);
-  const [isMemoEditing, setIsMemoEditing] = useState(false);
-  const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
-  const [isSummaryOverflowing, setIsSummaryOverflowing] = useState(false);
-
-  const {
-    root,
-    content,
-    header,
-    headerLeft,
-    headerBadge,
-    divider,
-    section,
-    titleCard,
-    actionRow,
-    linkActions,
-    imageWrapper,
-    summaryWrapper,
-    memoWrapper,
-  } = styles();
-
-  useEffect(() => {
-    setInternalTitle(title);
-  }, [title]);
-
-  useEffect(() => {
-    setInternalMemo(memo);
-  }, [memo]);
-
-  useEffect(() => {
-    setIsSummaryExpanded(false);
-  }, [summary]);
-
-  useEffect(() => {
-    const element = summaryRef.current;
-    if (!element) return undefined;
-
-    const shouldMeasure =
-      summaryStateProp === 'ready' || summaryStateProp === 'writing' || summaryStateProp === 'idle';
-    if (!shouldMeasure) return undefined;
-
-    const measureOverflow = () => {
-      const lineHeight = parseFloat(window.getComputedStyle(element).lineHeight || '0');
-      if (!lineHeight) {
-        setIsSummaryOverflowing(false);
-        return;
-      }
-
-      const wasClamped = element.classList.contains('line-clamp-5');
-      if (wasClamped) {
-        element.classList.remove('line-clamp-5');
-      }
-
-      const fullHeight = element.scrollHeight;
-      if (wasClamped) {
-        element.classList.add('line-clamp-5');
-      }
-
-      const maxHeight = lineHeight * 5;
-      setIsSummaryOverflowing(fullHeight > maxHeight + 1);
-    };
-
-    measureOverflow();
-
-    if (typeof ResizeObserver !== 'undefined') {
-      const resizeObserver = new ResizeObserver(() => measureOverflow());
-      resizeObserver.observe(element);
-      return () => resizeObserver.disconnect();
-    }
-
-    return undefined;
-  }, [summary, summaryStateProp]);
-
-  useEffect(() => {
-    if (isMemoEditing && memoAreaRef.current) {
-      memoAreaRef.current.focus();
-    }
-  }, [isMemoEditing]);
-
-  useEffect(() => {
-    if (isTitleEditing && titleAreaRef.current) {
-      titleAreaRef.current.focus();
-    }
-  }, [isTitleEditing]);
-
-  const renderHeaderActions =
-    headerActions !== undefined ? (
-      headerActions
-    ) : (
-      <div className="flex items-center gap-2">
-        <IconButton
-          icon="IC_Copy"
-          size="sm"
-          variant="tertiary_subtle"
-          contextStyle="onPanel"
-          ariaLabel="copy link"
-          onClick={() => {
-            if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText && safeUrl) {
-              navigator.clipboard.writeText(safeUrl);
-            }
-          }}
-        />
-        {onClose && (
-          <IconButton
-            icon="IC_Close"
-            size="sm"
-            variant="tertiary_subtle"
-            contextStyle="onPanel"
-            ariaLabel="close"
-            onClick={onClose}
-          />
-        )}
-      </div>
-    );
-
-  const renderTitleActions =
-    titleActions !== undefined ? (
-      titleActions
-    ) : onTitleChange ? (
-      <div className="flex items-center gap-2">
-        <IconButton
-          icon="IC_Copy"
-          size="sm"
-          variant="tertiary_subtle"
-          contextStyle="onPanel"
-          ariaLabel="copy title"
-          onClick={() => {
-            if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-              navigator.clipboard.writeText(internalTitle);
-            }
-          }}
-        />
-      </div>
-    ) : null;
-
-  const renderSummaryActions =
-    summaryActions !== undefined ? (
-      summaryActions
-    ) : summaryStateProp === 'loading' ||
-      summaryStateProp === 'error' ? null : onRegenerateSummary ||
-      (summary && isInteractiveSummary) ? (
-      <div className="flex items-center justify-end gap-2 pt-2">
-        {onRegenerateSummary && (
-          <Button
-            size="sm"
-            variant="tertiary_subtle"
-            contextStyle="onPanel"
-            icon="IC_SumGenerate"
-            label="요약 다시 생성"
-            onClick={onRegenerateSummary}
-          />
-        )}
-        {summary && isInteractiveSummary && (
-          <IconButton
-            size="sm"
-            variant="tertiary_subtle"
-            contextStyle="onPanel"
-            icon="IC_Copy"
-            ariaLabel="copy summary"
-            onClick={() => {
-              if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-                navigator.clipboard.writeText(summary);
-              }
-            }}
-          />
-        )}
-      </div>
-    ) : null;
-
-  const renderMemoActions = memoActions ?? null;
-
-  const renderSummaryBox = (children: React.ReactNode, footer?: React.ReactNode) => (
-    <div className="flex w-full flex-col items-center gap-4 px-5 py-6 text-center">
-      {children}
-      {footer}
-    </div>
-  );
-
-  const renderSummaryContent = () => {
-    if (summaryStateProp === 'loading') {
-      return (
-        <div className="text-gray500 flex min-h-[172px] w-full flex-col items-start justify-start gap-2 px-3 py-3">
-          <ProgressNotification
-            label="요약 생성 중..."
-            icon="IC_SumGenerate"
-            tone="default"
-            animated={false}
-            className="text-gray500 inline-flex items-center gap-2 px-0 py-0"
-          />
-        </div>
-      );
-    }
-
-    if (summaryStateProp === 'error') {
-      return (
-        <div className="flex flex-col items-center gap-4 px-2 py-4 text-center">
-          <ProgressNotification
-            icon="IC_Info"
-            label={summaryErrorMessage || '일시적 오류로 요약을 생성하지 못했습니다.'}
-            className="text-gray700 inline-flex items-center gap-3 px-4 py-3"
-          />
-          {onRetrySummary && (
-            <Button
-              size="sm"
-              variant="primary"
-              contextStyle="onPanel"
-              icon="IC_Regenerate"
-              label="다시 시도"
-              onClick={onRetrySummary}
-            />
-          )}
-        </div>
-      );
-    }
-
-    const showSummary =
-      summaryStateProp === 'ready' || summaryStateProp === 'writing' || summaryStateProp === 'idle';
-
-    if (!showSummary || !summary) {
-      return renderSummaryBox(
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-gray500 text-sm">요약이 아직 준비되지 않았어요.</p>
-        </div>
-      );
-    }
-
-    return (
-      <div className={summaryWrapper()}>
-        <div className="flex items-start gap-2">
-          <p
-            ref={summaryRef}
-            className={`font-body-md text-gray900 max-w-[480px] leading-[160%] whitespace-pre-wrap ${
-              isSummaryExpanded ? '' : 'line-clamp-5'
-            }`}
-          >
-            {summary}
-          </p>
-        </div>
-        {isSummaryOverflowing && (
-          <div className="text-gray500 mt-1 flex items-center gap-2">
-            <AccordionButton
-              isOpen={isSummaryExpanded}
-              setIsOpen={setIsSummaryExpanded}
-              openTitle="간략히"
-              closeTitle="자세히"
-            />
-          </div>
-        )}
-        {summaryStateProp === 'writing' && (
-          <p className="text-gray600 text-sm">요약을 다듬는 중이에요.</p>
-        )}
-      </div>
-    );
-  };
+  const { root, content } = styles();
+  const { modal } = useModalStore();
 
   return (
-    <aside className={root()}>
-      <div className={content()}>
-        {/* Header */}
-        <header className={header()}>
-          <div className="border-gray100 bg-gray50 flex flex-1 items-center gap-3 rounded-md border px-3 py-2">
-            <SVGIcon icon="IC_LinkOpen" size="md" className="text-gray600" aria-hidden="true" />
-            <div className="flex-1 truncate">
-              {safeUrl ? (
-                <Anchor href={safeUrl} target="_blank" size="sm" className="text-gray700">
-                  {safeUrl}
-                </Anchor>
-              ) : (
-                <span className="text-gray500 font-body-sm">유효하지 않은 URL</span>
-              )}
-            </div>
-            {renderHeaderActions}
-          </div>
-        </header>
-        <Divider color="gray200" className={divider()} />
+    <>
+      <aside className={root()}>
+        <div className={content()}>
+          {/* Header */}
+          <HeaderSection safeUrl={safeUrl} onClose={onClose} />
+          {/* Title */}
+          <TitleSection title={title} onTitleChange={onTitleChange} />
 
-        {/* Title */}
-        <section className={section()}>
-          {isTitleEditing ? (
-            <div
-              onBlur={e => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                  setIsTitleEditing(false);
-                }
-              }}
-            >
-              <Tooltip content="제목을 수정해 보세요">
-                <div className="w-[480px]">
-                  <TitleTextArea
-                    ref={titleAreaRef}
-                    value={internalTitle}
-                    placeholder="텍스트 에디터에서 제목을 수정해 주세요"
-                    maxLength={TITLE_MAX_LENGTH}
-                    onSubmit={() => setIsTitleEditing(false)}
-                    onChange={e => {
-                      const value = e.target.value;
-                      if (onTitleChange) {
-                        onTitleChange(value);
-                      } else {
-                        setInternalTitle(value);
-                      }
-                    }}
-                  />
-                </div>
-              </Tooltip>
-            </div>
-          ) : (
-            <Tooltip content="제목을 수정해 보세요">
-              <div
-                className={`${titleCard()} line-clamp-2`}
-                role="button"
-                tabIndex={0}
-                style={{ maxWidth: 480 }}
-                onClick={() => {
-                  setIsTitleEditing(true);
-                }}
-                onFocus={() => {
-                  setIsTitleEditing(true);
-                }}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    setIsTitleEditing(true);
-                  }
-                }}
-              >
-                <p className="font-body-md text-gray900 leading-[160%] whitespace-pre-wrap">
-                  {internalTitle}
-                </p>
-              </div>
-            </Tooltip>
-          )}
-          {renderTitleActions && <div className={actionRow()}>{renderTitleActions}</div>}
-          <div className={linkActions()}>
-            <Button
-              size="sm"
-              variant="tertiary_subtle"
-              contextStyle="onPanel"
-              icon="IC_LinkOpen"
-              label="링크 열기"
-              onClick={() => {
-                if (safeUrl) window.open(safeUrl, '_blank', 'noopener,noreferrer');
-              }}
-            />
-            <IconButton
-              size="sm"
-              variant="tertiary_subtle"
-              contextStyle="onPanel"
-              icon="IC_Copy"
-              ariaLabel="copy link"
-              onClick={() => {
-                if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-                  navigator.clipboard.writeText(safeUrl);
-                }
-              }}
-            />
-          </div>
-        </section>
+          {/* Image */}
+          <ImageSection imageUrl={imageUrl} title={title} />
 
-        {/* Image */}
-        <section className="px-0">
-          <div className={imageWrapper()}>
-            <Image
-              src={imageUrl || '/images/default_linkcard_image.png'}
-              alt={title || 'link preview image'}
-              width={520}
-              height={220}
-              className="h-full w-full object-cover"
-            />
-          </div>
-        </section>
+          {/* Summary */}
+          <SummarySection
+            linkId={id}
+            summary={summary}
+            summaryState={summaryStateProp}
+            summaryErrorMessage={summaryErrorMessage}
+            onRetrySummary={onRetrySummary}
+          />
 
-        {/* Summary */}
-        <section className={section()}>
-          <Label textSize="sm" className="text-gray900">
-            요약
-          </Label>
-          {renderSummaryContent()}
-          {renderSummaryActions}
-        </section>
-        <Divider color="gray200" className={divider()} />
-
-        {/* Memo */}
-        <section className={section()}>
-          <Label textSize="sm" className="text-gray900">
-            메모
-          </Label>
-          <Tooltip content="메모를 적어 두세요">
-            <div className={`${memoWrapper()} w-full max-w-full`}>
-              <TextArea
-                ref={memoAreaRef}
-                value={internalMemo}
-                className="w-full max-w-full"
-                heightLines={2}
-                maxHeightLines={6}
-                maxLength={isMemoEditing ? MEMO_MAX_LENGTH : undefined}
-                readOnly={!memoEditable || !isMemoEditing}
-                placeholder="메모를 입력해 주세요"
-                onClick={() => memoEditable && setIsMemoEditing(true)}
-                onFocus={() => memoEditable && setIsMemoEditing(true)}
-                onBlur={() => memoEditable && setIsMemoEditing(false)}
-                onChange={e => {
-                  const next = e.target.value;
-                  if (onMemoChange) {
-                    onMemoChange(next);
-                  } else {
-                    setInternalMemo(next);
-                  }
-                }}
-              />
-            </div>
-          </Tooltip>
-          {renderMemoActions && <div className={actionRow()}>{renderMemoActions}</div>}
-        </section>
-      </div>
-    </aside>
+          {/* Memo */}
+          <MemoSection memo={memo} memoEditable={memoEditable} onMemoChange={onMemoChange} />
+        </div>
+      </aside>
+      {modal.type === 'RE_SUMMARY' && <ReSummaryModal linkId={modal.props.linkId} />}
+    </>
   );
 };
 

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/HeaderSection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/HeaderSection.tsx
@@ -1,0 +1,53 @@
+import Anchor from '@/components/basics/Anchor/Anchor';
+import Divider from '@/components/basics/Divider/Divider';
+import IconButton from '@/components/basics/IconButton/IconButton';
+
+import CopyButton from '../../CopyButton';
+import { styles } from '../LinkCardDetailPanel.style';
+
+interface Props {
+  safeUrl: string;
+  onClose?: () => void;
+}
+
+export default function HeaderSection({ safeUrl, onClose }: Props) {
+  const { header } = styles();
+
+  return (
+    <div>
+      <header className={header()}>
+        <div className="bg-gray50 flex flex-1 items-center gap-3">
+          <div className="max-w-100 flex-1">
+            {safeUrl ? (
+              <Anchor href={safeUrl} target="_blank" className="text-gray400 truncate">
+                {safeUrl}
+              </Anchor>
+            ) : (
+              <span className="text-gray500 font-body-sm">유효하지 않은 URL입니다.</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <CopyButton
+              value={safeUrl}
+              successMsg="URL을 복사했습니다."
+              failMsg="URL 복사에 실패했습니다. 다시 시도해주세요."
+              tooltipMsg="URL 복사하기"
+              contextStyle="onPanel"
+            />
+            {onClose && (
+              <IconButton
+                icon="IC_Close"
+                size="sm"
+                variant="tertiary_subtle"
+                contextStyle="onPanel"
+                ariaLabel="상세패널 닫기"
+                onClick={onClose}
+              />
+            )}
+          </div>
+        </div>
+      </header>
+      <Divider />
+    </div>
+  );
+}

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/ImageSection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/ImageSection.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image';
+
+import { styles } from '../LinkCardDetailPanel.style';
+
+interface Props {
+  imageUrl: string | undefined;
+  title: string;
+}
+
+export default function ImageSection({ imageUrl, title }: Props) {
+  const { imageWrapper } = styles();
+
+  return (
+    <section>
+      <div className={imageWrapper()}>
+        <Image
+          src={imageUrl || '/images/default_linkcard_image.png'}
+          alt={title || '웹페이지 썸네일 이미지'}
+          width={520}
+          height={220}
+          className="h-full w-full object-cover"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/MemoSection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/MemoSection.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Label from '@/components/basics/Label/Label';
+import TextArea from '@/components/basics/TextArea/TextArea';
+import Tooltip from '@/components/basics/Tooltip/Tooltip';
+import { MAX_MEMO_LENGTH } from '@/lib/constants/link';
+import { useEffect, useRef, useState } from 'react';
+
+import CopyButton from '../../CopyButton';
+import { styles } from '../LinkCardDetailPanel.style';
+
+interface MemoSectionProps {
+  memo: string;
+  memoEditable?: boolean;
+  onMemoChange?: (value: string) => void;
+}
+
+export default function MemoSection({ memo, memoEditable = true, onMemoChange }: MemoSectionProps) {
+  const { section, linkActions, actionRow } = styles();
+
+  const [internalMemo, setInternalMemo] = useState(memo);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const memoAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setInternalMemo(memo);
+  }, [memo]);
+
+  useEffect(() => {
+    if (isEditing && memoAreaRef.current) {
+      memoAreaRef.current.focus();
+    }
+  }, [isEditing]);
+
+  const handleCommit = () => {
+    if (!memoEditable || !isEditing) return;
+    if (internalMemo !== memo) {
+      onMemoChange?.(internalMemo);
+    }
+    setIsEditing(false);
+  };
+
+  return (
+    <section className={section()}>
+      <Label textSize="sm" className="text-gray900">
+        메모
+      </Label>
+
+      <Tooltip content="메모를 적어 두세요">
+        <TextArea
+          ref={memoAreaRef}
+          value={internalMemo}
+          heightLines={2}
+          maxHeightLines={5}
+          maxLength={isEditing ? MAX_MEMO_LENGTH : undefined}
+          readOnly={!memoEditable || !isEditing}
+          placeholder="메모를 입력해 주세요"
+          onClick={() => memoEditable && setIsEditing(true)}
+          onFocus={() => memoEditable && setIsEditing(true)}
+          onSubmit={handleCommit}
+          onBlur={handleCommit}
+          onChange={e => setInternalMemo(e.target.value)}
+        />
+      </Tooltip>
+
+      <div className={linkActions()}>
+        <CopyButton
+          value={internalMemo}
+          successMsg="메모를 복사했습니다."
+          failMsg="메모 복사에 실패했습니다. 다시 시도해주세요."
+          tooltipMsg="메모 복사하기"
+          contextStyle="onPanel"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
@@ -1,0 +1,188 @@
+import AccordionButton from '@/components/basics/Accordion/AccordionButton/AccordionButton';
+import Button from '@/components/basics/Button/Button';
+import Divider from '@/components/basics/Divider/Divider';
+import Label from '@/components/basics/Label/Label';
+import ProgressNotification from '@/components/basics/ProgressNotification/ProgressNotification';
+import MarkdownRenderer from '@/hooks/util/parseMarkdown';
+import { useModalStore } from '@/stores/modalStore';
+import { useEffect, useRef, useState } from 'react';
+
+import CopyButton from '../../CopyButton';
+import { SummaryState } from '../LinkCardDetailPanel';
+import { styles } from '../LinkCardDetailPanel.style';
+
+interface SummarySectionProps {
+  linkId: number;
+  summary: string;
+  summaryState: SummaryState;
+  summaryErrorMessage?: string;
+  onRetrySummary?: () => void;
+}
+
+export default function SummarySection({
+  linkId,
+  summary,
+  summaryState,
+  summaryErrorMessage,
+  onRetrySummary,
+}: SummarySectionProps) {
+  const { section, summaryWrapper } = styles();
+
+  const summaryRef = useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [displayedSummary, setDisplayedSummary] = useState(summary);
+
+  const { open } = useModalStore();
+
+  // 타자 애니메이션
+  useEffect(() => {
+    if (summaryState !== 'writing') {
+      setDisplayedSummary(summary);
+      return;
+    }
+
+    setDisplayedSummary('');
+    let i = 0;
+    const interval = setInterval(() => {
+      setDisplayedSummary(prev => prev + summary[i]);
+      i++;
+      if (i >= summary.length) clearInterval(interval);
+    }, 30); // 글자 출력 속도(ms)
+
+    return () => clearInterval(interval);
+  }, [summary, summaryState]);
+
+  const isInteractive =
+    summaryState === 'ready' || summaryState === 'idle' || summaryState === 'writing';
+
+  const shouldShowSummary = isInteractive && Boolean(summary);
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [summary]);
+
+  useEffect(() => {
+    const element = summaryRef.current;
+    if (!element || !isInteractive) return;
+
+    const measureOverflow = () => {
+      const lineHeight = parseFloat(window.getComputedStyle(element).lineHeight || '0');
+      if (!lineHeight) return;
+
+      const wasClamped = element.classList.contains('line-clamp-5');
+      if (wasClamped) element.classList.remove('line-clamp-5');
+
+      const fullHeight = element.scrollHeight;
+
+      if (wasClamped) element.classList.add('line-clamp-5');
+
+      const maxHeight = lineHeight * 5;
+      setIsOverflowing(fullHeight > maxHeight + 1);
+    };
+
+    measureOverflow();
+
+    const observer = new ResizeObserver(measureOverflow);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [summary, summaryState, isInteractive]);
+
+  const renderContent = () => {
+    if (summaryState === 'loading') {
+      return (
+        <div className="flex min-h-[172px] flex-col gap-2 px-3 py-3">
+          <ProgressNotification
+            label="요약 생성 중..."
+            icon="IC_SumGenerate"
+            tone="default"
+            animated
+          />
+        </div>
+      );
+    }
+
+    if (summaryState === 'error' || !summary) {
+      return (
+        <div className="flex flex-col items-center gap-2 py-6 text-center">
+          <ProgressNotification
+            icon="IC_Info"
+            label={summaryErrorMessage || '일시적 오류로 요약을 생성하지 못했습니다.'}
+          />
+
+          <Button
+            size="sm"
+            variant="primary"
+            contextStyle="onPanel"
+            icon="IC_Regenerate"
+            label="다시 시도"
+            onClick={onRetrySummary}
+          />
+        </div>
+      );
+    }
+
+    if (!shouldShowSummary) return null;
+
+    return (
+      <div className={summaryWrapper()}>
+        <div
+          ref={summaryRef}
+          className={`font-body-md max-w-120 leading-[160%] ${isExpanded ? '' : 'line-clamp-5'}`}
+        >
+          <MarkdownRenderer content={summaryState === 'writing' ? displayedSummary : summary} />
+        </div>
+
+        {isOverflowing && (
+          <div className="mt-1">
+            <AccordionButton
+              isOpen={isExpanded}
+              setIsOpen={setIsExpanded}
+              openTitle="간략히"
+              closeTitle="자세히"
+            />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderActions = () => {
+    return (
+      <div className="flex items-center justify-end gap-2 pt-2">
+        <Button
+          size="sm"
+          variant="tertiary_subtle"
+          contextStyle="onPanel"
+          icon="IC_Regenerate"
+          label="요약 재생성"
+          onClick={() => open('RE_SUMMARY', { linkId: linkId })}
+        />
+
+        <CopyButton
+          value={summary}
+          successMsg="요약 내용을 복사했습니다."
+          failMsg="요약 내용 복사에 실패했습니다."
+          tooltipMsg="요약 내용 복사하기"
+          contextStyle="onPanel"
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <section className={section()}>
+        <Label textSize="sm" className="text-gray900">
+          요약
+        </Label>
+
+        {renderContent()}
+        {renderActions()}
+      </section>
+
+      <Divider />
+    </div>
+  );
+}

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/TitleSection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/TitleSection.tsx
@@ -1,0 +1,95 @@
+import { LINE_HEIGHTS } from '@/components/basics/TextArea/TextArea';
+import Tooltip from '@/components/basics/Tooltip/Tooltip';
+import { MAX_TITLE_LENGTH } from '@/lib/constants/link';
+import { useEffect, useRef, useState } from 'react';
+
+import CopyButton from '../../CopyButton';
+import { styles } from '../LinkCardDetailPanel.style';
+import TitleTextArea from '../TitleTextArea';
+
+interface TitleSectionProps {
+  title: string;
+  onTitleChange?: (value: string) => void;
+}
+
+export default function TitleSection({ title, onTitleChange }: TitleSectionProps) {
+  const { section, titleCard, linkActions } = styles();
+
+  const [internalTitle, setInternalTitle] = useState(title);
+  const [isTitleEditing, setIsTitleEditing] = useState(false);
+
+  const titleAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setInternalTitle(title);
+  }, [title]);
+
+  useEffect(() => {
+    if (isTitleEditing && titleAreaRef.current) {
+      titleAreaRef.current.focus();
+    }
+  }, [isTitleEditing]);
+
+  return (
+    <section className={section()}>
+      {isTitleEditing ? (
+        <div
+          onBlur={e => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              setIsTitleEditing(false);
+            }
+          }}
+        >
+          <Tooltip content="제목을 수정해 보세요">
+            <div className="w-full">
+              <TitleTextArea
+                ref={titleAreaRef}
+                value={internalTitle}
+                placeholder="텍스트 에디터에서 제목을 수정해 주세요"
+                maxLength={MAX_TITLE_LENGTH}
+                onSubmit={() => setIsTitleEditing(false)}
+                onChange={e => {
+                  const value = e.target.value;
+                  setInternalTitle(value);
+                  onTitleChange?.(value);
+                }}
+              />
+            </div>
+          </Tooltip>
+        </div>
+      ) : (
+        <Tooltip content="제목을 수정해 보세요">
+          <div
+            className={titleCard()}
+            style={{
+              minHeight: `${LINE_HEIGHTS.md * 2}px`,
+              maxHeight: `${LINE_HEIGHTS.md * 3}px`,
+            }}
+            role="button"
+            tabIndex={0}
+            onClick={() => setIsTitleEditing(true)}
+            onFocus={() => setIsTitleEditing(true)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setIsTitleEditing(true);
+              }
+            }}
+          >
+            <p className="font-body-md leading-[160%] whitespace-pre-wrap">{internalTitle}</p>
+          </div>
+        </Tooltip>
+      )}
+
+      <div className={linkActions()}>
+        <CopyButton
+          value={internalTitle}
+          successMsg="제목을 복사했습니다."
+          failMsg="제목 복사에 실패했습니다. 다시 시도해주세요."
+          tooltipMsg="제목 복사하기"
+          contextStyle="onPanel"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
+++ b/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
@@ -13,15 +13,15 @@ import PrevSummary from './PrevSummary';
 import useReSummary from './hooks/useReSummary';
 
 interface ReSummaryProps {
-  summaryId: number;
+  linkId: number;
 }
 
-export default function ReSummaryModal({ summaryId }: ReSummaryProps) {
-  const { mutate, isLoading, error, data } = useReSummary(summaryId);
+export default function ReSummaryModal({ linkId }: ReSummaryProps) {
+  const { mutate, isLoading, error, data } = useReSummary(linkId);
 
   useEffect(() => {
     mutate();
-  }, [mutate, summaryId]);
+  }, [mutate, linkId]);
 
   const prevContent = data?.existingSummary ?? '';
   const newContent = data?.newSummary ?? '';

--- a/src/hooks/util/parseMarkdown.tsx
+++ b/src/hooks/util/parseMarkdown.tsx
@@ -1,0 +1,93 @@
+// HTML 특수문자 이스케이프 (XSS 방지)
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function parseMarkdown(text: string): string {
+  // 1단계: 코드블록을 먼저 플레이스홀더로 추출 (내부 내용이 다른 regex에 오염되지 않도록)
+  const codeBlocks: string[] = [];
+  let processed = text.replace(/```[\w]*\n([\s\S]*?)```/g, (_, code) => {
+    const index = codeBlocks.length;
+    codeBlocks.push(
+      `<pre class="bg-gray800 text-green400 rounded p-3 text-sm overflow-x-auto my-2"><code>${escapeHtml(code)}</code></pre>`
+    );
+    return `%%CODEBLOCK_${index}%%`;
+  });
+
+  // 2단계: 인라인 코드도 플레이스홀더로 추출
+  const inlineCodes: string[] = [];
+  processed = processed.replace(/`([^`]+)`/g, (_, code) => {
+    const index = inlineCodes.length;
+    inlineCodes.push(`<code class="bg-gray200 rounded px-1 text-sm">${escapeHtml(code)}</code>`);
+    return `%%INLINECODE_${index}%%`;
+  });
+
+  // 3단계: 나머지 마크다운 변환 (코드블록 밖에서만 적용됨)
+  processed = processed
+    // 헤딩
+    .replace(
+      /^### (.+)$/gm,
+      (_, g1) => `<h3 class="text-base font-semibold mt-3 mb-1">${escapeHtml(g1)}</h3>`
+    )
+    .replace(
+      /^## (.+)$/gm,
+      (_, g1) => `<h2 class="text-lg font-semibold mt-4 mb-1">${escapeHtml(g1)}</h2>`
+    )
+    .replace(
+      /^# (.+)$/gm,
+      (_, g1) => `<h1 class="text-xl font-bold mt-4 mb-2">${escapeHtml(g1)}</h1>`
+    )
+    // bold
+    .replace(
+      /\*\*(.+?)\*\*/g,
+      (_, g1) => `<strong class="font-semibold">${escapeHtml(g1)}</strong>`
+    )
+    // 리스트
+    .replace(/^\s*- (.+)$/gm, (_, g1) => `<li class="ml-4 list-disc">${escapeHtml(g1)}</li>`)
+    // 표
+    .replace(/(\|.+\|\n)((\|[-:| ]+\|\n))((\|.+\|\n?)+)/g, match => {
+      const rows = match.trim().split('\n');
+      const headers = rows[0]
+        .split('|')
+        .filter(Boolean)
+        .map(
+          h =>
+            `<th class="border border-gray300 px-3 py-1 bg-gray100 font-semibold text-left">${escapeHtml(h.trim())}</th>`
+        )
+        .join('');
+      const bodyRows = rows
+        .slice(2)
+        .map(row => {
+          const cells = row
+            .split('|')
+            .filter(Boolean)
+            .map(c => `<td class="border border-gray300 px-3 py-1">${escapeHtml(c.trim())}</td>`)
+            .join('');
+          return `<tr>${cells}</tr>`;
+        })
+        .join('');
+      return `<table class="border-collapse w-full my-3 text-sm"><thead><tr>${headers}</tr></thead><tbody>${bodyRows}</tbody></table>`;
+    })
+    // 줄바꿈
+    .replace(/\n(?!<)/g, '<br/>');
+
+  // 4단계: 플레이스홀더를 실제 HTML로 복원
+  processed = processed.replace(/%%INLINECODE_(\d+)%%/g, (_, i) => inlineCodes[Number(i)]);
+  processed = processed.replace(/%%CODEBLOCK_(\d+)%%/g, (_, i) => codeBlocks[Number(i)]);
+
+  return processed;
+}
+
+export default function MarkdownRenderer({ content }: { content: string }) {
+  return (
+    <div
+      className="text-sm leading-relaxed"
+      dangerouslySetInnerHTML={{ __html: parseMarkdown(content) }}
+    />
+  );
+}

--- a/src/lib/constants/link.ts
+++ b/src/lib/constants/link.ts
@@ -1,0 +1,2 @@
+export const MAX_TITLE_LENGTH = 100;
+export const MAX_MEMO_LENGTH = 600;

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -1,4 +1,3 @@
-import { mockLinks } from '@/mocks';
 import type { LinkApiData } from '@/types/api/linkApi';
 import { create } from 'zustand';
 
@@ -10,10 +9,8 @@ type LinkStoreState = {
   updateLink: (id: number, updates: Partial<LinkApiData>) => void;
 };
 
-const useMockData = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
-
 export const useLinkStore = create<LinkStoreState>(set => ({
-  links: useMockData ? mockLinks : [],
+  links: [],
   selectedLinkId: null,
   setLinks: links => set({ links }),
   selectLink: id => set({ selectedLinkId: id }),

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -7,31 +7,27 @@ export const MODAL_TYPE = {
   DELETE_CHAT: 'DELETE_CHAT',
 } as const;
 
-type ModalProps = {
-  ADD_LINK?: Record<string, unknown>;
-  RE_SUMMARY?: Record<string, unknown>;
-  REPORT?: Record<string, unknown>;
-  DELETE_CHAT: { chatId: number; title: string };
-};
-
 export type ModalType = keyof typeof MODAL_TYPE | null;
+type ModalState =
+  | { type: null; props?: undefined }
+  | { type: 'ADD_LINK'; props?: Record<string, unknown> }
+  | { type: 'RE_SUMMARY'; props: { linkId: number } }
+  | { type: 'REPORT'; props?: Record<string, unknown> }
+  | { type: 'DELETE_CHAT'; props: { chatId: number; title: string } };
 
 interface ModalStore {
-  type: ModalType;
-  props?: ModalProps[keyof ModalProps];
-  // 함수 오버로딩
-  open(type: 'ADD_LINK', props?: ModalProps['ADD_LINK']): void;
-  open(type: 'RE_SUMMARY', props?: ModalProps['RE_SUMMARY']): void;
-  open(type: 'REPORT', props?: ModalProps['REPORT']): void;
-  open(type: 'DELETE_CHAT', props: ModalProps['DELETE_CHAT']): void;
+  modal: ModalState;
+  open(type: 'ADD_LINK', props?: Record<string, unknown>): void;
+  open(type: 'RE_SUMMARY', props: { linkId: number }): void;
+  open(type: 'REPORT', props?: Record<string, unknown>): void;
+  open(type: 'DELETE_CHAT', props: { chatId: number; title: string }): void;
   close: () => void;
 }
 
 export const useModalStore = create<ModalStore>(set => ({
-  type: null,
-  props: undefined,
-  open: ((type: keyof typeof MODAL_TYPE, props?: ModalProps[keyof ModalProps]) => {
-    set({ type, props });
+  modal: { type: null },
+  open: ((type: ModalType, props?: unknown) => {
+    set({ modal: { type, props } as ModalState });
   }) as ModalStore['open'],
-  close: () => set({ type: null, props: undefined }),
+  close: () => set({ modal: { type: null } }),
 }));

--- a/src/stories/LinkCardDetailPanel.stories.tsx
+++ b/src/stories/LinkCardDetailPanel.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
     layout: 'centered',
   },
   argTypes: {
+    id: { control: 'number' },
     url: { control: 'text' },
     title: { control: 'text' },
     summary: { control: 'text' },
@@ -23,19 +24,20 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const ControlledPanel = (props: Story['args']) => {
+  const [id, setId] = useState(props?.id ?? 1);
   const [title, setTitle] = useState(props?.title ?? '');
   const [memo, setMemo] = useState(props?.memo ?? '');
 
   return (
     <LinkCardDetailPanel
       {...props}
+      id={id}
       title={title}
       memo={memo}
       onTitleChange={setTitle}
       onMemoChange={setMemo}
       onClose={() => console.log('close panel')}
       onRetrySummary={props?.onRetrySummary ?? (() => console.log('retry summary'))}
-      onRegenerateSummary={props?.onRegenerateSummary ?? (() => console.log('regenerate summary'))}
     />
   );
 };
@@ -54,6 +56,7 @@ export const SummaryError: Story = {
   render: args => <ControlledPanel {...args} />,
   args: {
     ...baseArgs,
+    id: 1,
     summary: '',
     summaryState: 'error',
     summaryErrorMessage: '일시적 오류로 요약을 생성하지 못했습니다.',
@@ -65,6 +68,7 @@ export const SummaryLoading: Story = {
   render: args => <ControlledPanel {...args} />,
   args: {
     ...baseArgs,
+    id: 1,
     summary: '',
     summaryState: 'loading',
   },
@@ -75,6 +79,7 @@ export const SummaryReady: Story = {
   render: args => <ControlledPanel {...args} />,
   args: {
     ...baseArgs,
+    id: 1,
     summaryState: 'ready',
   },
 };

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -31,13 +31,13 @@ type Story = StoryObj<typeof Modal>;
 export const Default: Story = {
   render: args => {
     const StoryWrapper = () => {
-      const { type: openType, open, close } = useModalStore();
+      const { modal, open, close } = useModalStore();
 
       // args.type과 store 연동
       useEffect(() => {
-        if (openType === args.type) return;
+        if (modal.type === args.type) return;
         close();
-      }, [openType, close]);
+      }, [modal.type, close]);
 
       const handleOpen = () => {
         // 타입에 따라 적절한 props 전달
@@ -46,7 +46,7 @@ export const Default: Story = {
         } else if (args.type === 'ADD_LINK') {
           open('ADD_LINK');
         } else if (args.type === 'RE_SUMMARY') {
-          open('RE_SUMMARY');
+          open('RE_SUMMARY', { linkId: 123 });
         } else if (args.type === 'REPORT') {
           open('REPORT');
         }

--- a/src/stories/ReSummaryModal.stories.tsx
+++ b/src/stories/ReSummaryModal.stories.tsx
@@ -18,12 +18,16 @@ export default meta;
 type Story = StoryObj<typeof ReSummaryModal>;
 
 const StoryWrapper = () => {
-  const { type, open } = useModalStore();
+  const { modal, open } = useModalStore();
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Button label="모달 열기" variant="primary" onClick={() => open('RE_SUMMARY')} />
-      {type === 'RE_SUMMARY' && <ReSummaryModal summaryId={123} />}
+      <Button
+        label="모달 열기"
+        variant="primary"
+        onClick={() => open('RE_SUMMARY', { linkId: 123 })}
+      />
+      {modal.type === 'RE_SUMMARY' && <ReSummaryModal linkId={123} />}
     </QueryClientProvider>
   );
 };

--- a/src/stories/ReportModal.stories.tsx
+++ b/src/stories/ReportModal.stories.tsx
@@ -30,11 +30,11 @@ export default meta;
 type Story = StoryObj<typeof ReportModal>;
 
 const StoryWrapper = () => {
-  const { type, open } = useModalStore();
+  const { modal, open } = useModalStore();
   return (
     <>
       <Button label="모달 열기" variant="primary" onClick={() => open('REPORT')} />
-      {type === 'REPORT' && <ReportModal />}
+      {modal.type === 'REPORT' && <ReportModal />}
     </>
   );
 };


### PR DESCRIPTION
## 관련 이슈

- close #373

## PR 설명
- 상세정보 패널 최신 디자인 반영
- 섹션 분리
    - HeaderSection
    - TitleSection
    - ImageSection
    - SummarySection
    - MemoSection
- 모달 open 시 타입 전달 방식 수정
   - 타입만 전달하고 open은 store에서 처리

## 참고
- 현재 요약 재생성은 버튼 클릭 시 모달 띄우는 것까지만 제대로 돌아가게 구현되어 있습니다. 모달 내 구현은 다른 이슈 생성해서 이어서 작업 진행하겠습니다.