### PR TITLE
채팅방 삭제 토스트 띄우기 및 api 연결

### DIFF
--- a/src/components/basics/Button/Button.tsx
+++ b/src/components/basics/Button/Button.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import SVGIcon from '../../Icons/SVGIcon';
 import { IconMapTypes, buttonSizeMap } from '../../Icons/icons';
+import Spinner from '../Spinner/Spinner';
 import { style } from './Button.style';
 
 export interface ButtonProps extends Omit<
@@ -21,6 +22,7 @@ export interface ButtonProps extends Omit<
   radius?: 'md' | 'full';
   size?: 'sm' | 'md' | 'lg';
   disabled?: boolean;
+  loading?: boolean;
   onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
@@ -38,12 +40,14 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       radius = 'md',
       size = 'md',
       disabled = false,
+      loading = false,
       onClick,
       ...rest
     },
     ref
   ) => {
     // STYLES
+    const isDisabled = disabled || loading;
     const classes = style({
       variant,
       radius,
@@ -58,13 +62,19 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <Comp
         ref={ref}
         className={clsx(classes, className)}
-        disabled={disabled}
+        disabled={isDisabled}
         type={type}
-        aria-disabled={disabled}
-        onClick={onClick}
+        aria-disabled={isDisabled}
+        aria-busy={loading || undefined}
+        onClick={isDisabled ? undefined : onClick}
         {...rest}
       >
-        {asChild ? (
+        {loading ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <Spinner size={size} />
+            {label && <span className="sr-only">{label}</span>}
+          </div>
+        ) : asChild ? (
           children
         ) : (
           <div className="flex items-center gap-x-1">

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/ChatItem.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/ChatItem.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const ChatItem = ({ id, label }: Props) => {
   const router = useRouter();
-  const { type, open } = useModalStore();
+  const { open } = useModalStore();
 
   const handleItemClick = () => {
     router.push(`/chat/${id}`);
@@ -65,7 +65,7 @@ const ChatItem = ({ id, label }: Props) => {
                 onClick={e => {
                   e.stopPropagation();
                   close();
-                  open('DELETE_CHAT', { chatId: id });
+                  open('DELETE_CHAT', { chatId: id, title: label });
                 }}
               />
             )}

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/ChatRoomSection.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/ChatRoomSection.tsx
@@ -27,9 +27,11 @@ const ChatRoomSection = () => {
         </div>
       </div>
 
-      {type === 'DELETE_CHAT' && typeof props?.chatId === 'number' && (
-        <DeleteChatModal chatId={props.chatId} />
-      )}
+      {type === 'DELETE_CHAT' &&
+        typeof props?.chatId === 'number' &&
+        typeof props?.title === 'string' && (
+          <DeleteChatModal chatId={props.chatId} title={props.title} />
+        )}
     </>
   );
 };

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/DeleteChatModal.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/DeleteChatModal.tsx
@@ -2,17 +2,35 @@ import Button from '@/components/basics/Button/Button';
 import Modal from '@/components/basics/Modal/Modal';
 import { useDeleteChat } from '@/hooks/server/Chats/useDeleteChat';
 import { useModalStore } from '@/stores/modalStore';
+import { showToast } from '@/stores/toastStore';
 
-const DeleteChatModal = ({ chatId }: { chatId: number }) => {
+interface Props {
+  chatId: number;
+  title: string;
+}
+
+const DeleteChatModal = ({ chatId, title }: Props) => {
   const { close } = useModalStore();
   const { mutate, isPending } = useDeleteChat();
 
   const handleDelete = () => {
     mutate(chatId, {
-      onSuccess: () => close(),
+      onSuccess: () => {
+        showToast({
+          id: `delete_chatroom${chatId}_success`,
+          message: `"${title}" 채팅을 삭제했습니다.`,
+          variant: 'success',
+          duration: 2000,
+        });
+        close();
+      },
       onError: error => {
-        // TODO: error logic
-        console.error('채팅 삭제 실패: ', error);
+        showToast({
+          id: `delete_chatroom${chatId}_fail`,
+          message: '삭제에 실패했습니다. 잠시 후 다시 시도해주세요.',
+          variant: 'error',
+          duration: 2000,
+        });
       },
     });
   };
@@ -30,10 +48,11 @@ const DeleteChatModal = ({ chatId }: { chatId: number }) => {
           <Button variant="secondary" label="취소하기" className="flex-1" onClick={close} />
           <Button
             variant="primary"
-            label={isPending ? '삭제 중...' : '삭제하기'}
+            label="삭제하기"
             className="flex-1"
             onClick={handleDelete}
             disabled={isPending}
+            loading={isPending}
           />
         </div>
       </div>

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -11,7 +11,7 @@ type ModalProps = {
   ADD_LINK?: Record<string, unknown>;
   RE_SUMMARY?: Record<string, unknown>;
   REPORT?: Record<string, unknown>;
-  DELETE_CHAT: { chatId: number };
+  DELETE_CHAT: { chatId: number; title: string };
 };
 
 export type ModalType = keyof typeof MODAL_TYPE | null;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -42,7 +42,7 @@ export const Default: Story = {
       const handleOpen = () => {
         // 타입에 따라 적절한 props 전달
         if (args.type === 'DELETE_CHAT') {
-          open('DELETE_CHAT', { chatId: 1 }); // DELETE_CHAT은 props 필수
+          open('DELETE_CHAT', { chatId: 1, title: '어쩌구' }); // DELETE_CHAT은 props 필수
         } else if (args.type === 'ADD_LINK') {
           open('ADD_LINK');
         } else if (args.type === 'RE_SUMMARY') {


### PR DESCRIPTION
## 관련 이슈

- close #377

## PR 설명
### `Button.tsx`
- 로딩상태 props 추가 및 로딩 중 `Spinner` 컴포넌트 렌더링하도록 수정

### `ChatItem.tsx`
- 모달 열 때 `title`도 전달하도록 수정

### `ChatRoomSection.tsx`
- 삭제 모달에 stitle 전달

### `DeleteChatModal.tsx`
- api 연결
- 토스트 알림 추가
- 로딩중 버튼 상태 추가

### `modalStore.ts`
- `DELETE_CHAT`에 대해 `title` 타입 추가

## 실행 화면

https://github.com/user-attachments/assets/b331b39a-8389-4aba-997c-24f42be1a71a

