### PR TITLE
의존성있는 임시 토큰 제거

### DIFF
--- a/src/apis/chatSocket.ts
+++ b/src/apis/chatSocket.ts
@@ -1,4 +1,11 @@
-import { Client, type IFrame, type IMessage, type StompSubscription } from '@stomp/stompjs';
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
+import {
+  Client,
+  type IFrame,
+  type IMessage,
+  type StompHeaders,
+  type StompSubscription,
+} from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
 const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_BASE_URL;
@@ -7,13 +14,18 @@ if (!WS_BASE_URL) {
   throw new Error('Missing environment variable: NEXT_PUBLIC_WS_BASE_URL');
 }
 
-const authHeaderValue = () => {
-  const tokenEntry = document.cookie.split('; ').find(row => row.startsWith('accessToken='));
+const authHeaderValue = (): string | null => {
+  const tokenEntry = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${COOKIES_KEYS.ACCESS_TOKEN}=`));
   const token = tokenEntry
-    ? decodeURIComponent(tokenEntry.substring('accessToken='.length))
-    : undefined;
-  return `Bearer ${token ?? ''}`;
+    ? decodeURIComponent(tokenEntry.substring(`${COOKIES_KEYS.ACCESS_TOKEN}=`.length))
+    : '';
+  return token ? `Bearer ${token}` : null;
 };
+
+const withAuthorizationHeader = (authorization: string | null): StompHeaders =>
+  authorization ? { Authorization: authorization } : {};
 
 type Callback = () => void;
 
@@ -165,7 +177,7 @@ export const createChatSocket = (options: ChatSocketOptions): ChatSocket => {
     connectHeaders: {},
     beforeConnect: stompClient => {
       // 소켓 연결 시도마다 최신 토큰 사용하도록 함
-      stompClient.connectHeaders = { Authorization: authHeaderValue() };
+      stompClient.connectHeaders = withAuthorizationHeader(authHeaderValue());
     },
     reconnectDelay: 5000,
     onStompError: (frame: IFrame) => onError?.(frame),
@@ -216,7 +228,7 @@ export const createChatSocket = (options: ChatSocketOptions): ChatSocket => {
     client.publish({
       destination: SEND_DEST,
       body,
-      headers: { Authorization: authHeaderValue() },
+      headers: withAuthorizationHeader(authHeaderValue()),
     });
   };
 
@@ -231,7 +243,7 @@ export const createChatSocket = (options: ChatSocketOptions): ChatSocket => {
     client.publish({
       destination: CANCEL_DEST,
       body,
-      headers: { Authorization: authHeaderValue() },
+      headers: withAuthorizationHeader(authHeaderValue()),
     });
   };
 

--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -1,5 +1,6 @@
 import { type SafeFetchOptions, safeFetch } from '@/hooks/util/api/fetch/safeFetch';
 import { clientApiClient } from '@/lib/client/apiClient';
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import type {
   DeleteLinkApiResponse,
   DuplicateLinkApiResponse,
@@ -12,21 +13,14 @@ import type {
 } from '@/types/api/linkApi';
 import type { CreateLinkPayload, Link, UpdateLinkPayload } from '@/types/link';
 
-const API_URL = process.env.NEXT_PUBLIC_BASE_API_URL;
-const API_TOKEN = process.env.NEXT_PUBLIC_API_TOKEN;
-
-// BFF를 통하는 내부 엔드포인트
 const LINKS_BFF = '/api/links';
-
-if (!API_URL) {
-  throw new Error('Missing environment variable: NEXT_PUBLIC_BASE_API_URL');
-}
-
-if (!API_TOKEN) {
-  throw new Error('Missing environment variable: NEXT_PUBLIC_API_TOKEN');
-}
-
-const LINKS_ENDPOINT = `${API_URL}/v1/links`;
+const getLinksEndpoint = () => {
+  const apiUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+  if (!apiUrl) {
+    throw new Error('Missing environment variable: NEXT_PUBLIC_BASE_API_URL');
+  }
+  return `${apiUrl}/v1/links`;
+};
 
 export type LinkListParams = {
   lastId?: number | null;
@@ -44,20 +38,6 @@ function buildQuery(params?: LinkListParams) {
   return qs ? `?${qs}` : '';
 }
 
-const withAuth = (init?: SafeFetchOptions): SafeFetchOptions => {
-  const headers: HeadersInit = {
-    Authorization: `Bearer ${API_TOKEN}`,
-    ...(init?.headers ?? {}),
-  };
-
-  return {
-    timeout: 15_000,
-    jsonContentTypeCheck: true,
-    ...init,
-    headers,
-  };
-};
-
 const normalizeLink = (data: Partial<Link>): Link => {
   const now = new Date().toISOString();
 
@@ -70,6 +50,32 @@ const normalizeLink = (data: Partial<Link>): Link => {
     imageUrl: data.imageUrl ?? '',
     createdAt: data.createdAt ?? now,
     updatedAt: data.updatedAt ?? now,
+  };
+};
+
+const authHeaderValue = () => {
+  if (typeof document === 'undefined') return '';
+  const tokenEntry = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${COOKIES_KEYS.ACCESS_TOKEN}=`));
+  const token = tokenEntry
+    ? decodeURIComponent(tokenEntry.substring(`${COOKIES_KEYS.ACCESS_TOKEN}=`.length))
+    : '';
+  return token ? `Bearer ${token}` : '';
+};
+
+const withAuth = (init?: SafeFetchOptions): SafeFetchOptions => {
+  const authorization = authHeaderValue();
+  const headers: HeadersInit = {
+    ...(authorization ? { Authorization: authorization } : {}),
+    ...(init?.headers ?? {}),
+  };
+
+  return {
+    timeout: 15_000,
+    jsonContentTypeCheck: true,
+    ...init,
+    headers,
   };
 };
 
@@ -125,8 +131,9 @@ export const updateLink = async (id: number, payload: UpdateLinkPayload): Promis
 };
 
 export const updateLinkTitle = async (id: number, title: string): Promise<Link> => {
+  const linksEndpoint = getLinksEndpoint();
   const body = await safeFetch<LinkApiResponse>(
-    `${LINKS_ENDPOINT}/${id}/title`,
+    `${linksEndpoint}/${id}/title`,
     withAuth({
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -142,8 +149,9 @@ export const updateLinkTitle = async (id: number, title: string): Promise<Link> 
 };
 
 export const updateLinkMemo = async (id: number, memo: string): Promise<Link> => {
+  const linksEndpoint = getLinksEndpoint();
   const body = await safeFetch<LinkApiResponse>(
-    `${LINKS_ENDPOINT}/${id}/memo`,
+    `${linksEndpoint}/${id}/memo`,
     withAuth({
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -159,8 +167,9 @@ export const updateLinkMemo = async (id: number, memo: string): Promise<Link> =>
 };
 
 export const deleteLink = async (id: number): Promise<DeleteLinkApiResponse> => {
+  const linksEndpoint = getLinksEndpoint();
   const body = await safeFetch<DeleteLinkApiResponse>(
-    `${LINKS_ENDPOINT}/${id}`,
+    `${linksEndpoint}/${id}`,
     withAuth({ method: 'DELETE' })
   );
 
@@ -199,9 +208,10 @@ export const scrapeLinkMeta = async (url: string) => {
 };
 
 export const regenerateLinkSummary = async (id: number, format: LinkSummaryFormat) => {
+  const linksEndpoint = getLinksEndpoint();
   const usp = new URLSearchParams({ format });
   const body = await safeFetch<LinkSummaryRegenerateApiResponse>(
-    `${LINKS_ENDPOINT}/${id}/summary?${usp.toString()}`,
+    `${linksEndpoint}/${id}/summary?${usp.toString()}`,
     withAuth({ cache: 'no-store' })
   );
 

--- a/src/apis/summary.ts
+++ b/src/apis/summary.ts
@@ -1,16 +1,25 @@
 import { type SafeFetchOptions, safeFetch } from '@/hooks/util/api/fetch/safeFetch';
 import { SummaryData, SummaryResponse } from '@/types/api/summaryApi';
 
-const API_URL = process.env.NEXT_PUBLIC_BASE_API_URL;
-const API_TOKEN = process.env.NEXT_PUBLIC_API_TOKEN;
+const getSummaryEndpoint = () => {
+  const apiUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+  if (!apiUrl) {
+    throw new Error('Missing environment variable: NEXT_PUBLIC_BASE_API_URL');
+  }
+  return `${apiUrl}/v1/links`;
+};
 
-const SUMMARY_ENDPOINT = `${API_URL}/v1/links`;
-
-const authHeaderValue = () => `Bearer ${API_TOKEN}`;
+const authHeaderValue = () => {
+  if (typeof document === 'undefined') return '';
+  const tokenEntry = document.cookie.split('; ').find(row => row.startsWith('accessToken='));
+  const token = tokenEntry ? decodeURIComponent(tokenEntry.substring('accessToken='.length)) : '';
+  return token ? `Bearer ${token}` : '';
+};
 
 const withAuth = (init?: SafeFetchOptions): SafeFetchOptions => {
+  const authorization = authHeaderValue();
   const headers: HeadersInit = {
-    Authorization: authHeaderValue(),
+    ...(authorization ? { Authorization: authorization } : {}),
     ...(init?.headers ?? {}),
   };
 
@@ -28,13 +37,16 @@ type Params = {
 };
 
 export const fetchNewSummary = async (params: Params): Promise<SummaryData> => {
-  const url = new URL(`${SUMMARY_ENDPOINT}/${params.id}/summary`);
+  const summaryEndpoint = getSummaryEndpoint();
+  const url = `${summaryEndpoint}/${params.id}/summary`;
+  const searchParams = new URLSearchParams();
   if (params.format) {
-    url.searchParams.set('format', params.format);
+    searchParams.set('format', params.format);
   }
+  const endpoint = searchParams.toString() ? `${url}?${searchParams.toString()}` : url;
 
   const body = await safeFetch<SummaryResponse>(
-    url.toString(),
+    endpoint,
     withAuth({
       method: 'GET',
       timeout: 15_000,

--- a/src/app/(route)/home/page.tsx
+++ b/src/app/(route)/home/page.tsx
@@ -1,4 +1,5 @@
 // app/home/page.tsx
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import { cookies } from 'next/headers';
 
 import Home from './HomePage';
@@ -7,7 +8,7 @@ export const dynamic = 'force-dynamic';
 
 export default async function page() {
   const cookieStore = await cookies();
-  const token = cookieStore.get('accessToken');
+  const token = cookieStore.get(COOKIES_KEYS.ACCESS_TOKEN);
 
   console.log('🔥 Server side - Token exists:', !!token);
 

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -21,6 +21,7 @@ export async function POST() {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   } finally {
     cookieStore.delete(COOKIES_KEYS.ACCESS_TOKEN);
+    cookieStore.delete(COOKIES_KEYS.REFRESH_TOKEN);
     cookieStore.delete(COOKIES_KEYS.USER_INFO);
   }
 }

--- a/src/hooks/server/Chats/useStompChat.ts
+++ b/src/hooks/server/Chats/useStompChat.ts
@@ -1,20 +1,30 @@
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import { useChatStore } from '@/stores/chatStore';
-import { Client, type StompSubscription } from '@stomp/stompjs';
+import { Client, type StompHeaders, type StompSubscription } from '@stomp/stompjs';
 import { useEffect, useRef } from 'react';
 import SockJS from 'sockjs-client';
 
 const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_BASE_URL;
-const API_TOKEN = process.env.NEXT_PUBLIC_API_TOKEN;
 
 if (!WS_BASE_URL) {
   throw new Error('Missing environment variable: NEXT_PUBLIC_WS_BASE_URL');
 }
 
-if (!API_TOKEN) {
-  throw new Error('Missing environment variable: NEXT_PUBLIC_API_TOKEN');
-}
+const resolveAuthorization = (token?: string) => {
+  if (token) return `Bearer ${token}`;
 
-const authHeaderValue = () => `Bearer ${API_TOKEN}`;
+  if (typeof document !== 'undefined') {
+    const tokenEntry = document.cookie
+      .split('; ')
+      .find(row => row.startsWith(`${COOKIES_KEYS.ACCESS_TOKEN}=`));
+    const cookieToken = tokenEntry
+      ? decodeURIComponent(tokenEntry.substring(`${COOKIES_KEYS.ACCESS_TOKEN}=`.length))
+      : '';
+    if (cookieToken) return `Bearer ${cookieToken}`;
+  }
+
+  return null;
+};
 
 const WS_CHAT_ENDPOINT = `${WS_BASE_URL}/ws/chat`;
 const SUBSCRIBE_DEST = process.env.NEXT_PUBLIC_WS_SUBSCRIBE_DEST ?? '/user/queue/chat';
@@ -64,6 +74,9 @@ const parseIncoming = (rawBody: string): IncomingMessage => {
   };
 };
 
+const toStompHeaders = (authorization: string | null): StompHeaders =>
+  authorization ? { Authorization: authorization } : {};
+
 export const useStompChat = () => {
   const clientRef = useRef<Client | null>(null);
   const subscriptionRef = useRef<StompSubscription | null>(null);
@@ -98,7 +111,10 @@ export const useStompChat = () => {
     const client = new Client({
       webSocketFactory: () =>
         useSockJS ? new SockJS(socketEndpoint) : new WebSocket(socketEndpoint),
-      connectHeaders: { Authorization: token ? `Bearer ${token}` : authHeaderValue() },
+      connectHeaders: {},
+      beforeConnect: stompClient => {
+        stompClient.connectHeaders = toStompHeaders(resolveAuthorization(tokenRef.current));
+      },
       debug: () => {},
       reconnectDelay: 5000,
     });
@@ -159,23 +175,21 @@ export const useStompChat = () => {
     addMessage({ id: `${Date.now() + 1}`, role: 'ai', content: '...' });
     setGenerating(true);
 
+    const authorization = resolveAuthorization(tokenRef.current);
     clientRef.current.publish({
       destination: SEND_DEST,
       body: JSON.stringify({ chatId: Number(chatId), message: content }),
-      headers: {
-        Authorization: tokenRef.current ? `Bearer ${tokenRef.current}` : authHeaderValue(),
-      },
+      headers: toStompHeaders(authorization),
     });
   };
 
   const cancelGeneration = (chatId: string | number) => {
     if (!clientRef.current?.connected) return;
+    const authorization = resolveAuthorization(tokenRef.current);
     clientRef.current.publish({
       destination: CANCEL_DEST,
       body: JSON.stringify({ chatId: Number(chatId) }),
-      headers: {
-        Authorization: tokenRef.current ? `Bearer ${tokenRef.current}` : authHeaderValue(),
-      },
+      headers: toStompHeaders(authorization),
     });
   };
 

--- a/src/hooks/util/api/error/handleApiError.ts
+++ b/src/hooks/util/api/error/handleApiError.ts
@@ -1,4 +1,5 @@
 import { zodErrorToResponse } from '@/hooks/util/zodError';
+import { ApiError } from '@/lib/errors/ApiError';
 
 import { RequestValidationError } from '../request/requestError';
 import { FetchError, ParseError, TimeoutError } from './errors';
@@ -28,6 +29,16 @@ export function handleApiError(err: unknown): Response {
 
   if (err instanceof ParseError) {
     return Response.json({ success: false, message: 'Invalid upstream response' }, { status: 502 });
+  }
+
+  if (err instanceof ApiError) {
+    return Response.json(
+      {
+        success: false,
+        message: err.message,
+      },
+      { status: err.status }
+    );
   }
 
   return Response.json({ success: false, message: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
## 관련 이슈

- close #386 

## PR 설명

- NEXT_PUBLIC_API_TOKEN 의존 제거
링크/요약 API의 인증 헤더를 env 토큰이 아닌 브라우저 쿠키 accessToken 기준으로 구성
대상: src/apis/linkApi.ts, src/apis/summary.ts
- 소켓 인증 로직 정리
useStompChat에서 env 토큰 강제 체크 제거
전달받은 토큰 또는 쿠키 accessToken으로 Authorization 구성
대상: src/hooks/server/Chats/useStompChat.ts
쿠키 키 하드코딩 제거
accessToken 문자열 직접 사용 대신 COOKIES_KEYS.ACCESS_TOKEN 사용
대상: src/apis/chatSocket.ts, src/app/(route)/home/page.tsx
- 로그아웃 시 토큰 정리 강화
REFRESH_TOKEN 쿠키 삭제 추가
대상: src/app/api/auth/logout/route.ts
- API 에러 매핑 개선
ApiError를 500으로 뭉개지 않고 실제 status code(예: 401)로 반환
대상: src/hooks/util/api/error/handleApiError.ts
