### PR TITLE
accessToken 미일치 수정

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -1,6 +1,4 @@
-import { type SafeFetchOptions, safeFetch } from '@/hooks/util/api/fetch/safeFetch';
 import { clientApiClient } from '@/lib/client/apiClient';
-import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import type {
   DeleteLinkApiResponse,
   DuplicateLinkApiResponse,
@@ -14,13 +12,6 @@ import type {
 import type { CreateLinkPayload, Link, UpdateLinkPayload } from '@/types/link';
 
 const LINKS_BFF = '/api/links';
-const getLinksEndpoint = () => {
-  const apiUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
-  if (!apiUrl) {
-    throw new Error('Missing environment variable: NEXT_PUBLIC_BASE_API_URL');
-  }
-  return `${apiUrl}/v1/links`;
-};
 
 export type LinkListParams = {
   lastId?: number | null;
@@ -53,35 +44,9 @@ const normalizeLink = (data: Partial<Link>): Link => {
   };
 };
 
-const authHeaderValue = () => {
-  if (typeof document === 'undefined') return '';
-  const tokenEntry = document.cookie
-    .split('; ')
-    .find(row => row.startsWith(`${COOKIES_KEYS.ACCESS_TOKEN}=`));
-  const token = tokenEntry
-    ? decodeURIComponent(tokenEntry.substring(`${COOKIES_KEYS.ACCESS_TOKEN}=`.length))
-    : '';
-  return token ? `Bearer ${token}` : '';
-};
-
-const withAuth = (init?: SafeFetchOptions): SafeFetchOptions => {
-  const authorization = authHeaderValue();
-  const headers: HeadersInit = {
-    ...(authorization ? { Authorization: authorization } : {}),
-    ...(init?.headers ?? {}),
-  };
-
-  return {
-    timeout: 15_000,
-    jsonContentTypeCheck: true,
-    ...init,
-    headers,
-  };
-};
-
 // 전체 링크 fetch
 export const fetchLinks = async (params?: LinkListParams): Promise<LinkListViewData> => {
-  const body = await clientApiClient<LinkListApiResponse>(`/api/links${buildQuery(params)}`);
+  const body = await clientApiClient<LinkListApiResponse>(`${LINKS_BFF}${buildQuery(params)}`);
 
   if (!body?.data || !body.success) {
     throw new Error(body?.message ?? 'Invalid response');
@@ -95,7 +60,7 @@ export const fetchLinks = async (params?: LinkListParams): Promise<LinkListViewD
 
 // 링크 추가
 export const createLink = async (payload: CreateLinkPayload): Promise<Link> => {
-  const body = await clientApiClient<LinkApiResponse>('/api/links', {
+  const body = await clientApiClient<LinkApiResponse>(LINKS_BFF, {
     method: 'POST',
     body: JSON.stringify(payload),
   });
@@ -108,7 +73,7 @@ export const createLink = async (payload: CreateLinkPayload): Promise<Link> => {
 };
 
 export const fetchLink = async (id: number): Promise<Link> => {
-  const body = await clientApiClient<LinkApiResponse>(`/api/links/${id}`);
+  const body = await clientApiClient<LinkApiResponse>(`${LINKS_BFF}/${id}`);
 
   if (!body?.data || !body.success) {
     throw new Error(body?.message ?? 'Invalid response');
@@ -118,7 +83,7 @@ export const fetchLink = async (id: number): Promise<Link> => {
 };
 
 export const updateLink = async (id: number, payload: UpdateLinkPayload): Promise<Link> => {
-  const body = await clientApiClient<LinkApiResponse>(`/api/links/${id}`, {
+  const body = await clientApiClient<LinkApiResponse>(`${LINKS_BFF}/${id}`, {
     method: 'PUT',
     body: JSON.stringify(payload),
   });
@@ -131,15 +96,10 @@ export const updateLink = async (id: number, payload: UpdateLinkPayload): Promis
 };
 
 export const updateLinkTitle = async (id: number, title: string): Promise<Link> => {
-  const linksEndpoint = getLinksEndpoint();
-  const body = await safeFetch<LinkApiResponse>(
-    `${linksEndpoint}/${id}/title`,
-    withAuth({
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title }),
-    })
-  );
+  const body = await clientApiClient<LinkApiResponse>(`${LINKS_BFF}/${id}/title`, {
+    method: 'PATCH',
+    body: JSON.stringify({ title }),
+  });
 
   if (!body?.data || !body.success) {
     throw new Error(body?.message ?? 'Invalid response');
@@ -149,15 +109,10 @@ export const updateLinkTitle = async (id: number, title: string): Promise<Link> 
 };
 
 export const updateLinkMemo = async (id: number, memo: string): Promise<Link> => {
-  const linksEndpoint = getLinksEndpoint();
-  const body = await safeFetch<LinkApiResponse>(
-    `${linksEndpoint}/${id}/memo`,
-    withAuth({
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ memo }),
-    })
-  );
+  const body = await clientApiClient<LinkApiResponse>(`${LINKS_BFF}/${id}/memo`, {
+    method: 'PATCH',
+    body: JSON.stringify({ memo }),
+  });
 
   if (!body?.data || !body.success) {
     throw new Error(body?.message ?? 'Invalid response');
@@ -167,11 +122,9 @@ export const updateLinkMemo = async (id: number, memo: string): Promise<Link> =>
 };
 
 export const deleteLink = async (id: number): Promise<DeleteLinkApiResponse> => {
-  const linksEndpoint = getLinksEndpoint();
-  const body = await safeFetch<DeleteLinkApiResponse>(
-    `${linksEndpoint}/${id}`,
-    withAuth({ method: 'DELETE' })
-  );
+  const body = await clientApiClient<DeleteLinkApiResponse>(`${LINKS_BFF}/${id}`, {
+    method: 'DELETE',
+  });
 
   if (!body || typeof body.success !== 'boolean' || !body.status || !body.message) {
     throw new Error(body?.message ?? 'Invalid response');
@@ -208,11 +161,10 @@ export const scrapeLinkMeta = async (url: string) => {
 };
 
 export const regenerateLinkSummary = async (id: number, format: LinkSummaryFormat) => {
-  const linksEndpoint = getLinksEndpoint();
   const usp = new URLSearchParams({ format });
-  const body = await safeFetch<LinkSummaryRegenerateApiResponse>(
-    `${linksEndpoint}/${id}/summary?${usp.toString()}`,
-    withAuth({ cache: 'no-store' })
+  const body = await clientApiClient<LinkSummaryRegenerateApiResponse>(
+    `${LINKS_BFF}/${id}/summary?${usp.toString()}`,
+    { cache: 'no-store' }
   );
 
   if (!body?.data || !body.success) {

--- a/src/apis/report.ts
+++ b/src/apis/report.ts
@@ -1,8 +1,8 @@
-import { backendApiClient } from '@/lib/client/backendClient';
+import { clientApiClient } from '@/lib/client/apiClient';
 import type { ReportApiResponse, ReportRequest } from '@/types/api/report';
 
 export const createReport = async (payload: ReportRequest) => {
-  const res = await backendApiClient<ReportApiResponse>('/api/report', {
+  const res = await clientApiClient<ReportApiResponse>('/api/report', {
     method: 'POST',
     body: JSON.stringify(payload),
   });

--- a/src/apis/summary.ts
+++ b/src/apis/summary.ts
@@ -1,35 +1,5 @@
-import { type SafeFetchOptions, safeFetch } from '@/hooks/util/api/fetch/safeFetch';
+import { clientApiClient } from '@/lib/client/apiClient';
 import { SummaryData, SummaryResponse } from '@/types/api/summaryApi';
-
-const getSummaryEndpoint = () => {
-  const apiUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
-  if (!apiUrl) {
-    throw new Error('Missing environment variable: NEXT_PUBLIC_BASE_API_URL');
-  }
-  return `${apiUrl}/v1/links`;
-};
-
-const authHeaderValue = () => {
-  if (typeof document === 'undefined') return '';
-  const tokenEntry = document.cookie.split('; ').find(row => row.startsWith('accessToken='));
-  const token = tokenEntry ? decodeURIComponent(tokenEntry.substring('accessToken='.length)) : '';
-  return token ? `Bearer ${token}` : '';
-};
-
-const withAuth = (init?: SafeFetchOptions): SafeFetchOptions => {
-  const authorization = authHeaderValue();
-  const headers: HeadersInit = {
-    ...(authorization ? { Authorization: authorization } : {}),
-    ...(init?.headers ?? {}),
-  };
-
-  return {
-    timeout: 15_000,
-    jsonContentTypeCheck: true,
-    ...init,
-    headers,
-  };
-};
 
 type Params = {
   id: number;
@@ -37,22 +7,19 @@ type Params = {
 };
 
 export const fetchNewSummary = async (params: Params): Promise<SummaryData> => {
-  const summaryEndpoint = getSummaryEndpoint();
-  const url = `${summaryEndpoint}/${params.id}/summary`;
   const searchParams = new URLSearchParams();
   if (params.format) {
     searchParams.set('format', params.format);
   }
-  const endpoint = searchParams.toString() ? `${url}?${searchParams.toString()}` : url;
+  const endpoint = searchParams.toString()
+    ? `/api/links/${params.id}/summary?${searchParams.toString()}`
+    : `/api/links/${params.id}/summary`;
 
-  const body = await safeFetch<SummaryResponse>(
-    endpoint,
-    withAuth({
-      method: 'GET',
-      timeout: 15_000,
-      jsonContentTypeCheck: true,
-    })
-  );
+  const body = await clientApiClient<SummaryResponse>(endpoint, {
+    method: 'GET',
+    cache: 'no-store',
+  });
+
   if (!body?.data || !body.success) {
     throw new Error(body?.message ?? 'Invalid response structure');
   }

--- a/src/app/(route)/mypage/Mypage.tsx
+++ b/src/app/(route)/mypage/Mypage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { logout } from '@/apis/authApi';
 import Button from '@/components/basics/Button/Button';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -11,17 +12,8 @@ export default function Mypage() {
   const handleLogout = async () => {
     setIsLoggingOut(true);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_API_URL}/auth/logout`, {
-        method: 'POST',
-        credentials: 'include',
-      });
-
-      if (res.ok) {
-        router.push('/');
-      } else {
-        console.error('Logout failed');
-        alert('로그아웃에 실패했습니다.');
-      }
+      await logout();
+      router.push('/');
     } catch (err) {
       console.error('Logout error: ', err);
       alert('로그아웃 중 에러가 발생했습니다.');

--- a/src/app/api/links/[id]/memo/route.ts
+++ b/src/app/api/links/[id]/memo/route.ts
@@ -1,0 +1,17 @@
+import { handleApiError } from '@/hooks/util/api';
+import { serverApiClient } from '@/lib/server/apiClient';
+import { NextResponse } from 'next/server';
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const data = await serverApiClient(`/v1/links/${id}/memo`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
+    return NextResponse.json(data);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/app/api/links/[id]/route.ts
+++ b/src/app/api/links/[id]/route.ts
@@ -25,3 +25,15 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     return handleApiError(err);
   }
 }
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const data = await serverApiClient(`/v1/links/${id}`, {
+      method: 'DELETE',
+    });
+    return NextResponse.json(data);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/app/api/links/[id]/summary/route.ts
+++ b/src/app/api/links/[id]/summary/route.ts
@@ -1,0 +1,26 @@
+import { handleApiError } from '@/hooks/util/api';
+import { serverApiClient } from '@/lib/server/apiClient';
+import { NextResponse } from 'next/server';
+
+const ALLOWED_FORMATS = new Set(['CONCISE', 'DETAILED']);
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const { searchParams } = new URL(req.url);
+    const format = searchParams.get('format');
+
+    if (format !== null && !ALLOWED_FORMATS.has(format)) {
+      return NextResponse.json(
+        { success: false, message: 'Invalid format. Use CONCISE or DETAILED.' },
+        { status: 400 }
+      );
+    }
+
+    const query = format ? `?format=${encodeURIComponent(format)}` : '';
+    const data = await serverApiClient(`/v1/links/${id}/summary${query}`);
+    return NextResponse.json(data);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/app/api/links/[id]/title/route.ts
+++ b/src/app/api/links/[id]/title/route.ts
@@ -1,0 +1,17 @@
+import { handleApiError } from '@/hooks/util/api';
+import { serverApiClient } from '@/lib/server/apiClient';
+import { NextResponse } from 'next/server';
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const data = await serverApiClient(`/v1/links/${id}/title`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
+    return NextResponse.json(data);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- close #401

## PR 설명

- 배포 후 api에서 쿠키에 저장된 accessToken을 헤더에 포함하지 않는 현상을 해결했습니다.

### 1) 클라이언트 API 호출 경로 정리
- `src/apis/linkApi.ts`
  - 백엔드 직접 호출(`NEXT_PUBLIC_BASE_API_URL + /v1/...`) 제거
  - 링크 관련 API를 `/api/links/*` 경유로 통일
  - 대상: `title`, `memo`, `delete`, `summary regenerate` 포함
- `src/apis/summary.ts`
  - 요약 API 호출을 `/api/links/[id]/summary` 경유로 변경
- `src/apis/report.ts`
  - 리포트 API 호출을 `clientApiClient('/api/report')` 기반으로 통일
- `src/app/(route)/mypage/Mypage.tsx`
  - 로그아웃 직접 호출 제거
  - `logout()` 사용으로 `/api/auth/logout` 경유

### 2) BFF 라우트 보강
- `src/app/api/links/[id]/route.ts`
  - `DELETE` 핸들러 추가
- `src/app/api/links/[id]/title/route.ts` (신규)
  - `PATCH /title` 프록시 추가
- `src/app/api/links/[id]/memo/route.ts` (신규)
  - `PATCH /memo` 프록시 추가
- `src/app/api/links/[id]/summary/route.ts` (신규)
  - `GET /summary?format=...` 프록시 추가