### PR TITLE
채팅 페이지 답변 및 질문에 대한 기능 추가

### DIFF
--- a/src/apis/chatApi.ts
+++ b/src/apis/chatApi.ts
@@ -1,6 +1,8 @@
 // 백엔드 직접 호출
 import { clientApiClient } from '@/lib/client/apiClient';
 import type {
+  AddMessageFeedbackApiResponse,
+  AddMessageFeedbackPayload,
   ChatHistoryApiResponse,
   ChatHistoryData,
   ChatListApiResponse,
@@ -79,4 +81,23 @@ export const fetchChatMessages = async ({
   }
 
   return data;
+};
+
+export const addMessageFeedback = async (
+  messageId: number,
+  payload: AddMessageFeedbackPayload
+): Promise<AddMessageFeedbackApiResponse> => {
+  const response = await clientApiClient<AddMessageFeedbackApiResponse>(
+    `/api/messages/${messageId}/feedback`,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.success) {
+    throw new Error(response.message ?? 'Failed to add message feedback');
+  }
+
+  return response;
 };

--- a/src/app/(dev)/mock-chat/MockChatPage.tsx
+++ b/src/app/(dev)/mock-chat/MockChatPage.tsx
@@ -1,11 +1,17 @@
-'use client';
+﻿'use client';
 
+import { addMessageFeedback } from '@/apis/chatApi';
 import CardList from '@/components/basics/CardList/CardList';
 import LinkCard from '@/components/basics/LinkCard/LinkCard';
 import Tab from '@/components/basics/Tab/Tab';
+import CopyButton from '@/components/wrappers/CopyButton';
 import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
+import ReportModal from '@/components/wrappers/ReportModal/ReportModal';
+import { useModalStore } from '@/stores/modalStore';
+import { showToast } from '@/stores/toastStore';
 import { useState } from 'react';
 
+import AnswerActions, { type AnswerReaction } from '../../(route)/chat/_components/AnswerActions';
 import ChatQueryBox from '../../(route)/chat/_components/ChatQueryBox';
 
 type ChatLink = {
@@ -18,41 +24,48 @@ type ChatLink = {
 
 type ChatMessage = {
   id: string;
+  messageId?: number | null;
   role: 'user' | 'ai';
   text: string;
   links?: ChatLink[] | null;
+  reaction?: AnswerReaction;
 };
 
 const MOCK_RESPONSE = {
   content:
-    "네이버 쇼핑과 스토어(Plus Store)를 이용하시려면, '네이버+ 스토어' 링크(46)를 확인해 보세요. 현재 접속 시 '잠시 후 다시 확인해주세요' 오류가 표시되지만, 서비스가 정상화될 때까지 잠시 후 재접속하거나 '네이버 쇼핑 본문 바로가기' 및 '네이버홈 쇼핑&페이 고객센터'를 통해 문제 해결을 시도할 수 있습니다. 계정·포인트는 보유 중이므로 영향이 최소화됩니다. 2024년 기준 네이버 쇼핑은 현재 점검 중이니, 쇼핑 전 점검 진행 여부를 꼭 확인하세요.",
+    '네이버 쇼핑(플러스 스토어) 접속 오류가 반복될 때는 서비스 공지 확인, 앱/브라우저 재시도, 고객센터 문의 순서로 점검하는 것이 좋습니다. 계정 자체 문제보다는 일시적인 장애일 가능성이 높습니다.',
   links: [
     {
       linkId: 46,
-      title: '네이버+ 스토어',
+      title: '네이버 쇼핑',
       url: 'https://shopping.naver.com/',
       imageUrl:
         'https://linkiving-s3.s3.ap-northeast-2.amazonaws.com/links/5a4d2bc9-9159-35ac-b162-f882605fcbfb.png',
-      summary:
-        '네이버 쇼핑/스토어 안내 및 점검 상황 대응을 위한 임시 목데이터입니다. 서비스 오류 시 잠시 후 재접속하거나 고객센터를 이용하세요.',
+      summary: '네이버 쇼핑 서비스 현황 및 공지 확인용 예시 링크입니다.',
     },
   ] as ChatLink[],
 };
 
 const createAiMockMessage = (): ChatMessage => ({
   id: `${Date.now()}-${crypto.randomUUID()}`,
+  messageId: Date.now(),
   role: 'ai',
   text: MOCK_RESPONSE.content,
   links: MOCK_RESPONSE.links,
+  reaction: null,
 });
 
 export default function MockChatPage() {
+  const modal = useModalStore(state => state.modal);
+  const openModal = useModalStore(state => state.open);
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: 'mock-initial',
+      messageId: 1,
       role: 'ai',
-      text: '임시 채팅 페이지입니다. 질문을 보내면 API 없이 목응답이 즉시 표시됩니다.',
+      text: '목업 채팅 페이지입니다. 질문을 보내면 API 없이 고정 응답이 바로 표시됩니다.',
       links: MOCK_RESPONSE.links,
+      reaction: null,
     },
   ]);
   const [selectedLink, setSelectedLink] = useState<ChatLink | null>(null);
@@ -68,6 +81,65 @@ export default function MockChatPage() {
     ]);
   };
 
+  const handleReactionChange = async (message: ChatMessage, reaction: AnswerReaction) => {
+    const previousReaction = message.reaction ?? null;
+    setMessages(prev => prev.map(item => (item.id === message.id ? { ...item, reaction } : item)));
+
+    if (message.messageId == null) {
+      showToast({
+        message: '피드백을 전송할 메시지 ID를 찾을 수 없습니다.',
+        variant: 'error',
+        showIcon: true,
+      });
+      setMessages(prev =>
+        prev.map(item => (item.id === message.id ? { ...item, reaction: previousReaction } : item))
+      );
+      return;
+    }
+
+    const sentiment = reaction === 'up' ? 'LIKE' : reaction === 'down' ? 'DISLIKE' : 'NONE';
+
+    try {
+      await addMessageFeedback(message.messageId, { sentiment, text: '' });
+      if (reaction === 'up') {
+        showToast({
+          message: '감사합니다. 제공해 주신 피드백은 Linkiving을 개선하는 데 도움이 됩니다.',
+          variant: 'info',
+          showIcon: true,
+        });
+      }
+
+      if (reaction === 'down') {
+        showToast({
+          message: '아쉬운 점을 알려주셔서 감사합니다. 더 나은 답변을 위해 개선하겠습니다.',
+          variant: 'info',
+          showIcon: true,
+        });
+      }
+    } catch (err) {
+      setMessages(prev =>
+        prev.map(item => (item.id === message.id ? { ...item, reaction: previousReaction } : item))
+      );
+      showToast({
+        message: (err as Error).message ?? '피드백 전송에 실패했습니다.',
+        variant: 'error',
+        showIcon: true,
+      });
+    }
+  };
+
+  const handleRegenerate = () => {
+    showToast({
+      message: '재생성 기능은 목업에서 준비 중입니다.',
+      variant: 'info',
+      showIcon: true,
+    });
+  };
+
+  const handleMore = () => {
+    openModal('REPORT');
+  };
+
   return (
     <div className="h-screen w-full xl:flex">
       <div className="min-w-0 flex-1">
@@ -81,8 +153,19 @@ export default function MockChatPage() {
                 } ${index > 0 ? 'mt-[2rem]' : ''}`}
               >
                 {message.role === 'user' ? (
-                  <div className="bg-blue50 text-gray900 max-w-[70%] rounded-2xl px-4 py-3 whitespace-pre-wrap">
-                    {message.text}
+                  <div className="max-w-[70%]">
+                    <div className="bg-blue50 text-gray900 rounded-2xl px-4 py-3 whitespace-pre-wrap">
+                      {message.text}
+                    </div>
+                    <div className="mt-2 flex justify-end">
+                      <CopyButton
+                        value={message.text}
+                        successMsg="질문을 복사했습니다."
+                        failMsg="질문 복사에 실패했습니다."
+                        tooltipMsg="질문 복사하기"
+                        size="sm"
+                      />
+                    </div>
                   </div>
                 ) : (
                   <div className="w-full rounded-xl bg-white p-3">
@@ -108,6 +191,18 @@ export default function MockChatPage() {
                                 </CardList>
                               </div>
                             )}
+                            <div className="mt-3">
+                              <AnswerActions
+                                copyValue={message.text}
+                                menuKey={`answer-more-${message.id}`}
+                                reaction={message.reaction ?? null}
+                                onReactionChange={reaction =>
+                                  void handleReactionChange(message, reaction)
+                                }
+                                onRegenerate={handleRegenerate}
+                                onReport={handleMore}
+                              />
+                            </div>
                           </div>
                         ),
                         링크: (
@@ -158,6 +253,7 @@ export default function MockChatPage() {
           />
         </aside>
       )}
+      {modal.type === 'REPORT' && <ReportModal />}
     </div>
   );
 }

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -1,23 +1,30 @@
 ﻿'use client';
 
-import { fetchChatMessages } from '@/apis/chatApi';
+import { addMessageFeedback, fetchChatMessages } from '@/apis/chatApi';
 import type { ChatSocketLink, ChatSocketMessage } from '@/apis/chatSocket';
 import CardList from '@/components/basics/CardList/CardList';
 import LinkCard from '@/components/basics/LinkCard/LinkCard';
 import Tab from '@/components/basics/Tab/Tab';
+import CopyButton from '@/components/wrappers/CopyButton';
 import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
+import ReportModal from '@/components/wrappers/ReportModal/ReportModal';
 import { useChatStream } from '@/hooks/server/Chats/useChatStream';
+import { useModalStore } from '@/stores/modalStore';
+import { showToast } from '@/stores/toastStore';
 import type { ChatHistoryMessage } from '@/types/api/chatApi';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import AnswerActions, { type AnswerReaction } from '../_components/AnswerActions';
 import ChatQueryBox from '../_components/ChatQueryBox';
 
 type ChatMessage = {
   id: string;
+  messageId?: number | null;
   role: 'user' | 'ai' | 'system';
   text: string;
   links?: ChatSocketLink[] | null;
+  reaction?: AnswerReaction;
 };
 
 const PAGE_SIZE = 5;
@@ -33,14 +40,30 @@ const toLinks = (links: ChatHistoryMessage['links']): ChatSocketLink[] | null =>
   }));
 };
 
+const toReaction = (feedback?: string | null): AnswerReaction => {
+  if (feedback === 'LIKE') return 'up';
+  if (feedback === 'DISLIKE') return 'down';
+  return null;
+};
+
 const mapHistoryMessage = (message: ChatHistoryMessage): ChatMessage => ({
   id: `history-${message.id}`,
+  messageId: message.id,
   role: message.type === 'USER' ? 'user' : 'ai',
   text: message.content,
   links: toLinks(message.links),
+  reaction: toReaction(message.feedback),
 });
 
 const normalizeMessageText = (text: string) => text.trim();
+
+const mergeAiText = (prevText: string, nextText: string) => {
+  if (!prevText) return nextText;
+  if (!nextText) return prevText;
+  if (nextText.startsWith(prevText)) return nextText;
+  if (prevText.endsWith(nextText)) return prevText;
+  return `${prevText}${nextText}`;
+};
 
 export default function Chat() {
   const params = useParams();
@@ -50,6 +73,8 @@ export default function Chat() {
   const chatIdNum = useMemo(() => Number(chatId), [chatId]);
   const initialQuestion = useMemo(() => searchParams.get('q')?.trim() ?? '', [searchParams]);
   const initialSentRef = useRef(false);
+  const modal = useModalStore(state => state.modal);
+  const openModal = useModalStore(state => state.open);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [streamError, setStreamError] = useState<string | null>(null);
@@ -63,17 +88,78 @@ export default function Chat() {
   const pendingScrollAdjustRef = useRef<{ oldHeight: number; oldTop: number } | null>(null);
   const olderHistoryInFlightRef = useRef(false);
   const historyRequestSeqRef = useRef(0);
+  const reactionRequestSeqRef = useRef<Record<string, number>>({});
 
   const appendAiMessage = useCallback((payload: ChatSocketMessage) => {
-    setMessages(prev => [
-      ...prev,
-      {
-        id: `${Date.now()}-${crypto.randomUUID()}`,
-        role: 'ai',
-        text: payload.content,
-        links: payload.links,
-      },
-    ]);
+    setMessages(prev => {
+      const nextContent = payload.content ?? '';
+      const nextLinks = payload.links ?? null;
+
+      if (payload.messageId !== null) {
+        const sameMessageIndex = prev.findIndex(
+          message => message.role === 'ai' && message.messageId === payload.messageId
+        );
+
+        if (sameMessageIndex >= 0) {
+          return prev.map((message, index) =>
+            index === sameMessageIndex
+              ? {
+                  ...message,
+                  text: mergeAiText(message.text, nextContent),
+                  links: nextLinks ?? message.links ?? null,
+                }
+              : message
+          );
+        }
+
+        const unresolvedIndex = [...prev]
+          .reverse()
+          .findIndex(message => message.role === 'ai' && (message.messageId ?? null) === null);
+
+        if (unresolvedIndex >= 0) {
+          const targetIndex = prev.length - 1 - unresolvedIndex;
+          return prev.map((message, index) =>
+            index === targetIndex
+              ? {
+                  ...message,
+                  messageId: payload.messageId,
+                  text: mergeAiText(message.text, nextContent),
+                  links: nextLinks ?? message.links ?? null,
+                }
+              : message
+          );
+        }
+      } else {
+        const lastAiIndex = [...prev]
+          .reverse()
+          .findIndex(message => message.role === 'ai' && (message.messageId ?? null) === null);
+
+        if (lastAiIndex >= 0) {
+          const targetIndex = prev.length - 1 - lastAiIndex;
+          return prev.map((message, index) =>
+            index === targetIndex
+              ? {
+                  ...message,
+                  text: mergeAiText(message.text, nextContent),
+                  links: nextLinks ?? message.links ?? null,
+                }
+              : message
+          );
+        }
+      }
+
+      return [
+        ...prev,
+        {
+          id: `${Date.now()}-${crypto.randomUUID()}`,
+          messageId: payload.messageId,
+          role: 'ai',
+          text: nextContent,
+          links: nextLinks,
+          reaction: null,
+        },
+      ];
+    });
   }, []);
 
   const { connected, send } = useChatStream({
@@ -257,6 +343,85 @@ export default function Chat() {
     }
   }, [loadOlderHistory]);
 
+  const handleReactionChange = useCallback(
+    async (message: ChatMessage, reaction: AnswerReaction) => {
+      const previousReaction = message.reaction ?? null;
+      const requestSeq = (reactionRequestSeqRef.current[message.id] ?? 0) + 1;
+      reactionRequestSeqRef.current[message.id] = requestSeq;
+
+      setMessages(prev =>
+        prev.map(item => (item.id === message.id ? { ...item, reaction } : item))
+      );
+
+      if (message.messageId == null) {
+        showToast({
+          message: '피드백을 전송할 메시지 ID를 찾을 수 없습니다.',
+          variant: 'error',
+          showIcon: true,
+        });
+        setMessages(prev =>
+          prev.map(item =>
+            item.id === message.id ? { ...item, reaction: previousReaction } : item
+          )
+        );
+        return;
+      }
+
+      const sentiment = reaction === 'up' ? 'LIKE' : reaction === 'down' ? 'DISLIKE' : 'NONE';
+
+      try {
+        await addMessageFeedback(message.messageId, {
+          sentiment,
+          text: '',
+        });
+
+        if (reactionRequestSeqRef.current[message.id] !== requestSeq) return;
+
+        if (reaction === 'up') {
+          showToast({
+            message: '감사합니다. 제공해 주신 피드백은 Linkiving을 개선하는 데 도움이 됩니다.',
+            variant: 'info',
+            showIcon: true,
+          });
+        }
+
+        if (reaction === 'down') {
+          showToast({
+            message: '아쉬운 점을 알려주셔서 감사합니다. 더 나은 답변을 위해 개선하겠습니다.',
+            variant: 'info',
+            showIcon: true,
+          });
+        }
+      } catch (err) {
+        if (reactionRequestSeqRef.current[message.id] !== requestSeq) return;
+
+        setMessages(prev =>
+          prev.map(item =>
+            item.id === message.id ? { ...item, reaction: previousReaction } : item
+          )
+        );
+        showToast({
+          message: (err as Error).message ?? '피드백 전송에 실패했습니다.',
+          variant: 'error',
+          showIcon: true,
+        });
+      }
+    },
+    []
+  );
+
+  const handleRegenerate = useCallback(() => {
+    showToast({
+      message: '재생성 기능은 준비 중입니다.',
+      variant: 'info',
+      showIcon: true,
+    });
+  }, []);
+
+  const handleReport = useCallback(() => {
+    openModal('REPORT');
+  }, [openModal]);
+
   return (
     <div className="h-screen w-full xl:flex">
       <div className="min-w-0 flex-1">
@@ -288,8 +453,19 @@ export default function Chat() {
                 } ${index > 0 ? 'mt-[2rem]' : ''}`}
               >
                 {message.role === 'user' ? (
-                  <div className="bg-blue50 text-gray900 max-w-[70%] rounded-2xl px-4 py-3 whitespace-pre-wrap">
-                    {message.text}
+                  <div className="max-w-[70%]">
+                    <div className="bg-blue50 text-gray900 rounded-2xl px-4 py-3 whitespace-pre-wrap">
+                      {message.text}
+                    </div>
+                    <div className="mt-2 flex justify-end">
+                      <CopyButton
+                        value={message.text}
+                        successMsg="질문을 복사했습니다."
+                        failMsg="질문 복사에 실패했습니다."
+                        tooltipMsg="질문 복사하기"
+                        size="sm"
+                      />
+                    </div>
                   </div>
                 ) : (
                   <div className="w-full rounded-xl border border-gray-200 bg-white p-3">
@@ -313,6 +489,20 @@ export default function Chat() {
                                     />
                                   ))}
                                 </CardList>
+                              </div>
+                            )}
+                            {message.role === 'ai' && (
+                              <div className="mt-3">
+                                <AnswerActions
+                                  copyValue={message.text}
+                                  menuKey={`answer-more-${message.id}`}
+                                  reaction={message.reaction ?? null}
+                                  onReactionChange={reaction =>
+                                    void handleReactionChange(message, reaction)
+                                  }
+                                  onRegenerate={handleRegenerate}
+                                  onReport={handleReport}
+                                />
                               </div>
                             )}
                           </div>
@@ -365,6 +555,7 @@ export default function Chat() {
           />
         </aside>
       )}
+      {modal.type === 'REPORT' && <ReportModal />}
     </div>
   );
 }

--- a/src/app/(route)/chat/_components/AnswerActions.tsx
+++ b/src/app/(route)/chat/_components/AnswerActions.tsx
@@ -1,0 +1,118 @@
+﻿'use client';
+
+import Button from '@/components/basics/Button/Button';
+import IconButton from '@/components/basics/IconButton/IconButton';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/basics/Popover';
+import Tooltip from '@/components/basics/Tooltip/Tooltip';
+import CopyButton from '@/components/wrappers/CopyButton';
+
+export type AnswerReaction = 'up' | 'down' | null;
+
+interface AnswerActionsProps {
+  copyValue: string;
+  menuKey: string;
+  reaction?: AnswerReaction;
+  onReactionChange: (reaction: AnswerReaction) => void;
+  onRegenerate?: () => void;
+  onReport?: () => void;
+}
+
+export default function AnswerActions({
+  copyValue,
+  menuKey,
+  reaction = null,
+  onReactionChange,
+  onRegenerate,
+  onReport,
+}: AnswerActionsProps) {
+  const noActiveBgClass =
+    'text-gray500 hover:bg-transparent active:bg-transparent focus:bg-transparent focus-visible:outline-none';
+  const copyButtonClass =
+    'text-gray500 hover:bg-transparent active:!bg-gray100 focus:!bg-gray100 focus-visible:outline-none';
+  const moreButtonClass =
+    'text-gray500 hover:bg-transparent active:bg-transparent focus:bg-transparent focus-visible:outline-none aria-expanded:border-gray300 aria-expanded:!bg-gray100';
+
+  return (
+    <div className="mb-3 flex items-center gap-1.5">
+      <CopyButton
+        value={copyValue}
+        successMsg="답변을 복사했습니다."
+        failMsg="답변 복사에 실패했습니다."
+        tooltipMsg="답변 복사"
+        size="md"
+        className={copyButtonClass}
+      />
+
+      <Tooltip content="좋아요" side="bottom">
+        <div>
+          <IconButton
+            icon={reaction === 'up' ? 'IC_ThumbUpFilled' : 'IC_ThumbUpOutline'}
+            size="md"
+            variant="tertiary_subtle"
+            contextStyle="onMain"
+            className={noActiveBgClass}
+            ariaLabel="좋아요"
+            onClick={() => onReactionChange(reaction === 'up' ? null : 'up')}
+          />
+        </div>
+      </Tooltip>
+
+      <Tooltip content="싫어요" side="bottom">
+        <div>
+          <IconButton
+            icon={reaction === 'down' ? 'IC_ThumbDownFilled' : 'IC_ThumbDownOutline'}
+            size="md"
+            variant="tertiary_subtle"
+            contextStyle="onMain"
+            className={noActiveBgClass}
+            ariaLabel="싫어요"
+            onClick={() => onReactionChange(reaction === 'down' ? null : 'down')}
+          />
+        </div>
+      </Tooltip>
+
+      <Tooltip content="다시 생성" side="bottom">
+        <div>
+          <IconButton
+            icon="IC_Regenerate"
+            size="md"
+            variant="tertiary_subtle"
+            contextStyle="onMain"
+            className={noActiveBgClass}
+            ariaLabel="다시 생성"
+            onClick={onRegenerate}
+          />
+        </div>
+      </Tooltip>
+
+      <Popover placement="top-start">
+        <PopoverTrigger popoverKey={menuKey}>
+          <IconButton
+            icon="IC_MoreVert"
+            size="md"
+            variant="tertiary_subtle"
+            contextStyle="onMain"
+            className={moreButtonClass}
+            ariaLabel="더보기"
+          />
+        </PopoverTrigger>
+        <PopoverContent popoverKey={menuKey}>
+          {close => (
+            <Button
+              label="문제 보내기"
+              variant="tertiary_subtle"
+              contextStyle="onPanel"
+              size="sm"
+              radius="full"
+              className="m-2 !bg-transparent hover:!bg-transparent focus:!bg-transparent active:!bg-transparent"
+              onClick={() => {
+                close();
+                onReport?.();
+              }}
+            />
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/app/api/messages/[messageId]/feedback/route.ts
+++ b/src/app/api/messages/[messageId]/feedback/route.ts
@@ -1,0 +1,45 @@
+import { handleApiError } from '@/hooks/util/api';
+import { serverApiClient } from '@/lib/server/apiClient';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const parseRequiredInt = (value: string) => {
+  if (!/^\d+$/.test(value)) return { valid: false, parsed: null as number | null };
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) return { valid: false, parsed: null as number | null };
+  return { valid: true, parsed };
+};
+
+const feedbackBodySchema = z.object({
+  sentiment: z.enum(['LIKE', 'DISLIKE', 'NONE']),
+  text: z.string().max(20).optional(),
+});
+
+export async function POST(req: Request, { params }: { params: Promise<{ messageId: string }> }) {
+  try {
+    const { messageId } = await params;
+    const parsedId = parseRequiredInt(messageId);
+    if (!parsedId.valid) {
+      return NextResponse.json(
+        {
+          success: false,
+          status: 'BAD_REQUEST',
+          message: 'Invalid path parameter: messageId must be numeric.',
+        },
+        { status: 400 }
+      );
+    }
+
+    const rawBody = await req.json();
+    const body = feedbackBodySchema.parse(rawBody);
+    const data = await serverApiClient(`/v1/messages/${messageId}/feedback`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+
+    return NextResponse.json(data);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/components/wrappers/CopyButton.tsx
+++ b/src/components/wrappers/CopyButton.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { showToast } from '@/stores/toastStore';
+import { useEffect, useState } from 'react';
 
 import IconButton, { IconButtonProps } from '../basics/IconButton/IconButton';
 import Tooltip from '../basics/Tooltip/Tooltip';
@@ -25,8 +28,12 @@ export default function CopyButton({
   onClick,
   ...iconButtonProps
 }: CopyButtonProps) {
-  const isClipboardSupported =
-    typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.writeText);
+  const [isClipboardSupported, setIsClipboardSupported] = useState(false);
+
+  useEffect(() => {
+    setIsClipboardSupported(Boolean(navigator.clipboard?.writeText));
+  }, []);
+
   const isDisabled = Boolean(disabled) || !value || !isClipboardSupported;
 
   const handleCopyClick: NonNullable<IconButtonProps['onClick']> = async event => {

--- a/src/types/api/chatApi.ts
+++ b/src/types/api/chatApi.ts
@@ -50,3 +50,16 @@ export interface ChatHistoryData {
 }
 
 export type ChatHistoryApiResponse = ApiResponseBase<ChatHistoryData>;
+
+export type FeedbackSentiment = 'LIKE' | 'DISLIKE' | 'NONE';
+
+export interface AddMessageFeedbackPayload {
+  sentiment: FeedbackSentiment;
+  text?: string;
+}
+
+export interface AddMessageFeedbackData {
+  id: number;
+}
+
+export type AddMessageFeedbackApiResponse = ApiResponseBase<AddMessageFeedbackData>;


### PR DESCRIPTION
## 관련 이슈

- close #409

## PR 설명

### 1) 답변 액션 바 컴포넌트화 및 UI 정합
- `AnswerActions` 컴포넌트 추가/확장
- 액션 구성:
  - 답변 복사
  - 좋아요 / 싫어요 (토글)
  - 다시 생성
  - 더보기
- 스타일 정리:
  - 아이콘 컬러 및 상태 컬러 정합
  - 더보기 버튼 활성 상태(원형 배경/아이콘 색) 반영
  - 불필요한 active/hover 배경 제거 요구사항 반영

### 2) 질문 복사 UI 위치 조정
- 사용자 질문 복사 버튼을 말풍선 내부가 아니라 **질문 박스 하단 우측**으로 이동
- `ChatPage`, `MockChatPage` 모두 동일하게 반영

### 3) 피드백 API 연동 (LIKE / DISLIKE / NONE)
- 클라이언트 API 추가:
  - `addMessageFeedback(messageId, payload)`
- BFF API 라우트 추가:
  - `POST /api/messages/[messageId]/feedback`
  - 백엔드 `/v1/messages/{messageId}/feedback`로 프록시
- 요청 검증 추가:
  - `sentiment`: `LIKE | DISLIKE | NONE`
  - `text`: optional, max 20

### 4) 좋아요/싫어요 토스트 처리
- 좋아요 성공 시 안내 토스트 출력
- 싫어요 성공 시 안내 토스트 출력
- 실패 시 롤백 + 에러 토스트

### 5) 소켓 messageId 기반 매핑 안정화
- ChatPage의 AI 메시지 처리 로직을 `messageId` 기준 upsert로 개선
  - 같은 `messageId` 수신 시 기존 메시지 업데이트
  - `messageId` 지연 수신 시 미해결 AI 메시지에 연결
- 결과적으로 like/dislike가 **해당 답변 messageId**로 정확히 호출되도록 보강

### 6) 더보기 → 문제 보내기 연결
- 더보기 버튼에 Popover 메뉴(`문제 보내기`) 추가
- 클릭 시 `ReportModal` 오픈
- `ChatPage`, `MockChatPage` 모두 연결

### 7) hydration 오류 수정
- `CopyButton`의 클립보드 지원 판별을 렌더 시점에서 제거하고 `useEffect`로 이관
- SSR/CSR 불일치로 인한 hydration mismatch 해소

## 변경 파일 (핵심)
- `src/app/(route)/chat/[id]/ChatPage.tsx`
- `src/app/(dev)/mock-chat/MockChatPage.tsx`
- `src/app/(route)/chat/_components/AnswerActions.tsx`
- `src/components/wrappers/CopyButton.tsx`
- `src/apis/chatApi.ts`
- `src/types/api/chatApi.ts`
- `src/app/api/messages/[messageId]/feedback/route.ts`
