### PR TITLE
링크카드 디자인 개선

### DIFF
--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -96,7 +96,10 @@ export default function AllLink() {
         <div className="min-w-0 flex-1 px-6 py-8 lg:px-10">
           <div className="mx-auto flex h-full w-full max-w-200 flex-col gap-5">
             <header className="flex items-center justify-between">
-              <h1 className="font-title-md">전체 링크</h1>
+              <div className="flex items-center gap-1">
+                <h1 className="font-title-md">전체 링크</h1>
+                <p className="font-body-md text-gray600">({links.length})</p>
+              </div>
               {hasSelection && (
                 <Button
                   ref={deleteButtonRef}

--- a/src/components/basics/LinkCard/LinkCard.tsx
+++ b/src/components/basics/LinkCard/LinkCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { getSafeUrl } from '@/hooks/util/getSafeUrl';
+import MarkdownRenderer from '@/hooks/util/parseMarkdown';
 import { useInteractiveKeyBlock } from '@/hooks/util/useInteractiveKeyBlock';
 import Image from 'next/image';
 import React from 'react';
@@ -42,7 +43,7 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
   return (
     <div
       ref={ref}
-      className="border-gray200 hover:bg-gray50 active:bg-blue50 focus:border-blue500 group relative flex aspect-47/58 w-full cursor-pointer flex-col overflow-hidden rounded-2xl border transition-colors"
+      className="border-gray200 hover:bg-gray50 active:bg-blue50 focus:border-blue500 group relative flex aspect-47/58 w-full min-w-35 cursor-pointer flex-col overflow-hidden rounded-2xl border transition-colors"
       tabIndex={0}
       onClick={onClick}
       onKeyDown={handleKeyDown}
@@ -94,6 +95,7 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
           src={imageUrl ? imageUrl : '/images/default_linkcard_image.png'}
           alt={title}
           fill
+          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
           className="border-gray200 border-b object-cover"
         />
       </div>
@@ -104,14 +106,17 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
             <Anchor
               href={safeHref}
               aria-label={`${title} 페이지 링크 열기`}
-              className="[&>span]:max-w-35"
+              className="min-w-0 [&>span]:max-w-full [&>span]:truncate"
             >
               {link}
             </Anchor>
           </div>
         </div>
         {!!summary ? (
-          <span className="text-etc-linkcard-summary font-body-sm line-clamp-2">{summary}</span>
+          <MarkdownRenderer
+            className="text-etc-linkcard-summary font-body-sm line-clamp-2"
+            content={summary}
+          />
         ) : (
           <div className="font-body-sm text-etc-linkcard-summary flex justify-end">
             <span>{SUMMARY_FAIL_TEXT}</span>

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
@@ -132,6 +132,7 @@ export default function SummarySection({
           className={`font-body-md max-w-120 leading-[160%] ${isExpanded ? '' : 'line-clamp-5'}`}
         >
           <MarkdownRenderer
+            className="text-body-md"
             content={summaryState === 'writing' ? displayedSummary : (summary ?? '')}
           />
         </div>

--- a/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
+++ b/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
@@ -75,15 +75,15 @@ export default function ReSummaryModal({ linkId }: ReSummaryProps) {
                 <span className="font-label-sm">기존 요약</span>
                 <div className="rounded-lg bg-white p-2">
                   <div className="custom-scrollbar font-body-md h-45 overflow-y-auto pr-1 wrap-break-word">
-                    <MarkdownRenderer content={prevContent} />
+                    <MarkdownRenderer className="text-body-md" content={prevContent} />
                   </div>
                 </div>
               </div>
               <div className="flex flex-1 flex-col gap-2">
                 <span className="font-label-sm">재생성 요약</span>
                 <div className="rounded-lg bg-white p-2">
-                  <div className="custom-scrollbar font-body-md h-45 overflow-auto pr-1 wrap-break-word">
-                    <MarkdownRenderer content={newContent} />
+                  <div className="custom-scrollbar font-body-md h-45 overflow-auto pr-1">
+                    <MarkdownRenderer className="text-body-md" content={newContent} />
                   </div>
                 </div>
               </div>

--- a/src/hooks/util/parseMarkdown.tsx
+++ b/src/hooks/util/parseMarkdown.tsx
@@ -87,11 +87,14 @@ function parseMarkdown(text: string): string {
   return processed;
 }
 
-export default function MarkdownRenderer({ content }: { content: string }) {
+export default function MarkdownRenderer({
+  content,
+  className,
+}: {
+  content: string;
+  className: string;
+}) {
   return (
-    <div
-      className="text-sm leading-relaxed"
-      dangerouslySetInnerHTML={{ __html: parseMarkdown(content ?? '') }}
-    />
+    <div className={className} dangerouslySetInnerHTML={{ __html: parseMarkdown(content ?? '') }} />
   );
 }


### PR DESCRIPTION
## 관련 이슈

- close #427

## PR 설명
- 최소크기 지정하여 UI 깨짐 방지
- `Anchor` className을 `max-w-full`로 수정하여 링크카드 너비에 맞춰 `truncat` 그리도록 수정
- `<Image/>`에 size 지정하여 경고 방지
- 링크카드 요약에 `MarkdownRenderer` 적용 및 `MarkdownRenderer` props에 `clssName` 추가하여 사용처별로 다른 디자인 적용할 수 있도록 수정