### PR TITLE
배포 환경 로그아웃 시 쿠키 미삭제 및 페이지 이동 불가 수정

### DIFF
--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,22 +1,30 @@
-'use client';
-
 import { logout } from '@/apis/authApi';
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+
+import { deleteCookieUtil } from './useCookie';
 
 export function useLogout() {
   const router = useRouter();
   const queryClient = useQueryClient();
 
+  const clearCookies = () => {
+    deleteCookieUtil(COOKIES_KEYS.ACCESS_TOKEN);
+    deleteCookieUtil(COOKIES_KEYS.REFRESH_TOKEN);
+    deleteCookieUtil(COOKIES_KEYS.USER_INFO);
+  };
+
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
+      clearCookies();
       queryClient.clear();
       router.push('/');
     },
     onError: () => {
+      clearCookies();
       queryClient.clear();
-      // 에러가 나도 로그인 페이지로 이동
       router.push('/');
     },
   });


### PR DESCRIPTION
## 관련 이슈

- close #439

## PR 설명
**원인**
- 쿠키를 클라이언트(`document.cookie`)에서 설정했으나 클라이언트(`useLogout.ts`)에 쿠키 삭제 로직이 없어서 실패
- 로컬에서는 `middleware`에서 dev일 경우 쿠키 검사를 건너뛰도록 하여 동작이 잘 됐던 것으로 추정

**변경 사항**
- `useLogout`에서 로그아웃 성공/실패 시 클라이언트에서 직접 `deleteCookieUtil`로 쿠키 삭제하도록 수정