### PR TITLE
링크카드상세패널 제목 툴팁 문구 수정

### DIFF
--- a/src/components/wrappers/LinkCardDetailPanel/Sections/TitleSection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/TitleSection.tsx
@@ -82,7 +82,7 @@ export default function TitleSection({ linkId, title, onTitleChange }: TitleSect
           </Tooltip>
         </div>
       ) : (
-        <Tooltip content="제목을 수정해 보세요" disabled={isTitleEditing}>
+        <Tooltip content="제목 수정하기" disabled={isTitleEditing}>
           <div
             className={titleCard()}
             style={{


### PR DESCRIPTION
## 관련 이슈

- close #454 

## PR 설명

- .TitleSection.tsx 툴팁 문구를 제목을 수정해보세요 -> 제목 수정하기 로 변경하였습니다.