### PR TITLE
채팅 답변 링크 요약 실패

### DIFF
--- a/src/app/(dev)/mock-chat/MockChatPage.tsx
+++ b/src/app/(dev)/mock-chat/MockChatPage.tsx
@@ -184,7 +184,7 @@ export default function MockChatPage() {
                                       key={link.linkId}
                                       title={link.title}
                                       link={link.url}
-                                      summary=""
+                                      summary={link.summary ?? ''}
                                       imageUrl={link.imageUrl ?? ''}
                                       onClick={() => setSelectedLink(link)}
                                     />
@@ -215,7 +215,7 @@ export default function MockChatPage() {
                                     key={link.linkId}
                                     title={link.title}
                                     link={link.url}
-                                    summary=""
+                                    summary={link.summary ?? ''}
                                     imageUrl={link.imageUrl ?? ''}
                                     onClick={() => setSelectedLink(link)}
                                   />

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -483,7 +483,7 @@ export default function Chat() {
                                       key={link.linkId}
                                       title={link.title}
                                       link={link.url}
-                                      summary=""
+                                      summary={link.summary ?? ''}
                                       imageUrl={link.imageUrl ?? ''}
                                       onClick={() => setSelectedLink(link)}
                                     />
@@ -516,7 +516,7 @@ export default function Chat() {
                                     key={link.linkId}
                                     title={link.title}
                                     link={link.url}
-                                    summary=""
+                                    summary={link.summary ?? ''}
                                     imageUrl={link.imageUrl ?? ''}
                                     onClick={() => setSelectedLink(link)}
                                   />


### PR DESCRIPTION
## 관련 이슈

- close #460 

## PR 설명

- ChatPage.tsx에서 요약이 있는지 확인하고 요약 실패 배너를 띄우도록 설정했습니다.
***
현재 로컬로 소켓 답변을 받을 수 없어 동일하게 mock데이터를 넣은 MockChatPage.tsx로 확인하도록 동일하게 수정했습니다. 확인시에 해당 부분 참고바랍니다.
배포시 예상되는 화면입니다. (MockChatPage.tsx 화면)
<img width="1291" height="700" alt="image" src="https://github.com/user-attachments/assets/fced988f-590c-431f-93a6-27737ee973ca" />
