### PR TITLE
전체 링크 개수 api 연결

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -3,6 +3,7 @@ import type {
   DeleteLinkApiResponse,
   DuplicateLinkApiResponse,
   LinkApiResponse,
+  LinkCountApiResponse,
   LinkListApiResponse,
   LinkListViewData,
   LinkMetaScrapeApiResponse,
@@ -61,6 +62,16 @@ export const fetchLinks = async (params?: LinkListParams): Promise<LinkListViewD
     ...body.data,
     content: body.data.links.map(normalizeLink),
   };
+};
+
+export const fetchLinksCount = async (): Promise<number> => {
+  const body = await clientApiClient<LinkCountApiResponse>('/api/links/count');
+
+  if (!body?.data || typeof body.data.totalCount !== 'number') {
+    throw new Error(body?.message ?? 'Invalid response');
+  }
+
+  return body.data.totalCount;
 };
 
 // 링크 추가

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -9,6 +9,7 @@ import Spinner from '@/components/basics/Spinner/Spinner';
 import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
 import { useGetInfiniteLinks } from '@/hooks/useGetInfiniteLinks';
 import { useGetLink } from '@/hooks/useGetLink';
+import useLinkCount from '@/hooks/useGetLinksCount';
 import { useLinkStore } from '@/stores/linkStore';
 import { useModalStore } from '@/stores/modalStore';
 import { useEffect, useRef, useState } from 'react';
@@ -21,6 +22,8 @@ export default function AllLink() {
 
   const listRef = useRef<HTMLDivElement>(null);
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
+
+  const { count } = useLinkCount();
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -101,7 +104,7 @@ export default function AllLink() {
             <header className="flex items-center justify-between">
               <div className="flex items-center gap-1">
                 <h1 className="font-title-md">전체 링크</h1>
-                <p className="font-body-md text-gray600">({links.length})</p>
+                <p className="font-body-md text-gray600">({count ?? links.length})</p>
               </div>
               {hasSelection && (
                 <Button

--- a/src/app/api/links/count/route.ts
+++ b/src/app/api/links/count/route.ts
@@ -1,0 +1,11 @@
+import { handleApiError } from '@/hooks/util/api';
+import { serverApiClient } from '@/lib/server/apiClient';
+
+export async function GET() {
+  try {
+    const data = await serverApiClient('/v1/links/count');
+    return new Response(JSON.stringify(data), { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/hooks/useGetLinksCount.ts
+++ b/src/hooks/useGetLinksCount.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { fetchLinksCount } from '@/apis/linkApi';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useLinkCount() {
+  const query = useQuery({
+    queryKey: ['linkCount'],
+    queryFn: fetchLinksCount,
+  });
+
+  return {
+    count: query.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/src/types/api/linkApi.ts
+++ b/src/types/api/linkApi.ts
@@ -9,6 +9,11 @@ export interface ApiResponseBase<T> {
   timestamp?: string;
 }
 
+export interface LinkCountResponse {
+  totalCount: number;
+}
+export type LinkCountApiResponse = ApiResponseBase<LinkCountResponse>;
+
 export interface LinkRes {
   id: number;
   url: string;


### PR DESCRIPTION
## 관련 이슈

- close #462 

## PR 설명
- 전체 링크 페이지 화면 상단에 저장한 총 링크 개수 보이도록 함
- Docker 배포 이후 개발된 내용으로, 로컬 테스트 불가능
- 에러 및 로딩에 대해서는 단순 현재 화면의 링크 개수 출력하도록 처리