### PR TITLE
링크카드 요약 중 상태 적용

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -47,6 +47,9 @@ const normalizeLink = (
     imageUrl: data.imageUrl ?? '',
     createdAt: data.createdAt ?? now,
     updatedAt: data.updatedAt ?? now,
+    summaryStatus: data.summaryStatus,
+    summaryProgress: data.summaryProgress,
+    summaryUpdatedAt: data.summaryUpdatedAt,
   };
 };
 

--- a/src/apis/summarySocket.ts
+++ b/src/apis/summarySocket.ts
@@ -1,0 +1,233 @@
+'use client';
+
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
+import { getAccessToken } from '@/stores/tokenStore';
+import {
+  Client,
+  type IFrame,
+  type IMessage,
+  type StompHeaders,
+  type StompSubscription,
+} from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_BASE_URL;
+
+if (!WS_BASE_URL) {
+  throw new Error('Missing environment variable: NEXT_PUBLIC_WS_BASE_URL');
+}
+
+const WS_SUMMARY_ENDPOINT = `${WS_BASE_URL}/ws/link`;
+const SUBSCRIBE_DEST = process.env.NEXT_PUBLIC_WS_SUMMARY_SUBSCRIBE_DEST ?? '/user/queue/summary';
+const WS_DEBUG = process.env.NEXT_PUBLIC_WS_DEBUG === 'true';
+
+const authHeaderFromClientState = (): string | null => {
+  const tokenEntry = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${COOKIES_KEYS.ACCESS_TOKEN}=`));
+  const cookieToken = tokenEntry
+    ? decodeURIComponent(tokenEntry.substring(`${COOKIES_KEYS.ACCESS_TOKEN}=`.length))
+    : '';
+  const token = cookieToken || getAccessToken() || '';
+
+  return token ? `Bearer ${token}` : null;
+};
+
+const withAuthorizationHeader = (authorization: string | null): StompHeaders =>
+  authorization ? { Authorization: authorization } : {};
+
+export type SummaryStatusPayload = {
+  linkId: number;
+  status: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+  progress?: number;
+  summary?: string;
+  errorMessage?: string;
+  updatedAt?: string;
+};
+
+export type LinkSummaryStatus = 'idle' | 'generating' | 'ready' | 'failed';
+
+export type SummaryStatusEvent = {
+  linkId: number;
+  status: LinkSummaryStatus;
+  progress?: number;
+  summary?: string;
+  errorMessage?: string;
+  updatedAt?: string;
+};
+
+type Callback = () => void;
+
+export type SummarySocketOptions = {
+  useSockJS?: boolean;
+  onEvent: (event: SummaryStatusEvent) => void;
+  onError?: (err: unknown) => void;
+  onConnect?: Callback;
+  onDisconnect?: Callback;
+};
+
+const toSockJsUrl = (url: string) => {
+  if (/^http/i.test(url)) return url;
+  return url.replace(/^ws(s?):\/\//i, (_, secure) => `http${secure ?? ''}://`);
+};
+
+const toWebSocketUrl = (url: string) => {
+  if (/^ws/i.test(url)) return url;
+  return url.replace(/^http(s?):\/\//i, (_, secure) => `ws${secure ?? ''}://`);
+};
+
+const SUMMARY_STATUS_MAP: Record<SummaryStatusPayload['status'], LinkSummaryStatus> = {
+  PENDING: 'generating',
+  PROCESSING: 'generating',
+  COMPLETED: 'ready',
+  FAILED: 'failed',
+};
+
+const coerceSummaryStatus = (status: SummaryStatusPayload['status']): LinkSummaryStatus => {
+  if (status in SUMMARY_STATUS_MAP) {
+    return SUMMARY_STATUS_MAP[status];
+  }
+
+  throw new Error(`Invalid summary status event: unsupported status "${String(status)}".`);
+};
+
+const parsePayload = (rawBody: string): SummaryStatusEvent => {
+  const payload = JSON.parse(rawBody) as SummaryStatusPayload;
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('Invalid summary status event payload');
+  }
+
+  const linkId = Number(payload.linkId);
+  if (!Number.isFinite(linkId)) {
+    throw new Error('Invalid summary status event: missing linkId.');
+  }
+
+  if (!payload.status || typeof payload.status !== 'string') {
+    throw new Error('Invalid summary status event: missing status.');
+  }
+
+  return {
+    linkId,
+    status: coerceSummaryStatus(payload.status as SummaryStatusPayload['status']),
+    progress: typeof payload.progress === 'number' ? payload.progress : undefined,
+    summary: typeof payload.summary === 'string' ? payload.summary : undefined,
+    errorMessage: typeof payload.errorMessage === 'string' ? payload.errorMessage : undefined,
+    updatedAt: typeof payload.updatedAt === 'string' ? payload.updatedAt : undefined,
+  };
+};
+
+const logWsDebug = (...args: unknown[]) => {
+  if (!WS_DEBUG) return;
+  console.debug('[summary-socket]', ...args);
+};
+
+export type SummarySocket = {
+  connect: () => Promise<void>;
+  disconnect: () => void;
+};
+
+export const createSummarySocket = ({
+  useSockJS = true,
+  onEvent,
+  onError,
+  onConnect,
+  onDisconnect,
+}: SummarySocketOptions): SummarySocket => {
+  let currentAuthorization: string | null = null;
+  let connectAttempt = 0;
+  let disconnected = false;
+  let subscription: StompSubscription | null = null;
+
+  const socketEndpoint = useSockJS
+    ? toSockJsUrl(WS_SUMMARY_ENDPOINT)
+    : toWebSocketUrl(WS_SUMMARY_ENDPOINT);
+
+  const client = new Client({
+    webSocketFactory: () => {
+      console.log('[summary-socket] creating socket to', socketEndpoint);
+      return useSockJS ? new SockJS(socketEndpoint) : new WebSocket(socketEndpoint);
+    },
+    connectHeaders: {},
+    beforeConnect: stompClient => {
+      stompClient.connectHeaders = withAuthorizationHeader(currentAuthorization);
+    },
+    reconnectDelay: 5000,
+    onStompError: (frame: IFrame) => {
+      console.error('[summary-socket] stomp error', {
+        command: frame.command,
+        headers: frame.headers,
+        body: frame.body,
+      });
+      onError?.(frame);
+    },
+    onWebSocketError: err => {
+      console.error('[summary-socket] websocket error', {
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        error: err,
+      });
+      onError?.(err);
+    },
+    onWebSocketClose: () => {
+      console.warn('[summary-socket] websocket closed');
+      onDisconnect?.();
+    },
+  });
+
+  client.onConnect = () => {
+    console.log('[summary-socket] connected to', SUBSCRIBE_DEST);
+    logWsDebug('connected', { subscribe: SUBSCRIBE_DEST });
+    onConnect?.();
+    subscription = client.subscribe(SUBSCRIBE_DEST, (message: IMessage) => {
+      try {
+        console.log('[summary-socket] raw message', message.body);
+        logWsDebug('raw-message', message.body);
+        const event = parsePayload(message.body);
+        console.log('[summary-socket] parsed event', event);
+        logWsDebug('parsed-event', event);
+        onEvent(event);
+      } catch (error) {
+        console.error('[summary-socket] parse error', error);
+        logWsDebug('parse-error', error);
+        onError?.(error);
+      }
+    });
+  };
+
+  const connect = async () => {
+    const attempt = ++connectAttempt;
+    disconnected = false;
+
+    currentAuthorization = authHeaderFromClientState();
+
+    console.log('[summary-socket] connect attempt', attempt, {
+      currentAuthorization: !!currentAuthorization,
+    });
+
+    if (disconnected || attempt !== connectAttempt) {
+      logWsDebug('connect-aborted', { attempt, connectAttempt, disconnected });
+      console.warn('[summary-socket] connect aborted', { attempt, connectAttempt, disconnected });
+      return;
+    }
+
+    if (!currentAuthorization) {
+      const error = new Error('Cannot connect: authentication token is unavailable.');
+      logWsDebug('connect-auth-missing');
+      console.error('[summary-socket] auth missing');
+      onError?.(error);
+      return;
+    }
+
+    client.activate();
+  };
+
+  const disconnect = () => {
+    disconnected = true;
+    console.log('[summary-socket] disconnected');
+    subscription?.unsubscribe();
+    client.deactivate();
+    onDisconnect?.();
+  };
+
+  return { connect, disconnect };
+};

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -10,20 +10,34 @@ import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkC
 import { useGetInfiniteLinks } from '@/hooks/useGetInfiniteLinks';
 import { useGetLink } from '@/hooks/useGetLink';
 import useLinkCount from '@/hooks/useGetLinksCount';
+import { useSummaryStatusSocket } from '@/hooks/useSummaryStatusSocket';
 import { useLinkStore } from '@/stores/linkStore';
 import { useModalStore } from '@/stores/modalStore';
-import { useEffect, useRef, useState } from 'react';
+import type { LinkSummaryStatus } from '@/types/link';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 export default function AllLink() {
   const { selectedLinkId, selectLink } = useLinkStore();
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [summaryStatusByLinkId, setSummaryStatusByLinkId] = useState<
+    Record<
+      number,
+      {
+        status: LinkSummaryStatus;
+        progress?: number;
+        summary?: string;
+        errorMessage?: string;
+      }
+    >
+  >({});
   const { modal, open } = useModalStore();
 
   const listRef = useRef<HTMLDivElement>(null);
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
 
   const { count } = useLinkCount();
+  const processingLinkIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -44,6 +58,58 @@ export default function AllLink() {
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useGetInfiniteLinks();
 
+  useSummaryStatusSocket({
+    enabled: true,
+    onConnect: () => {
+      console.log('[summary-socket] connected to backend');
+    },
+    onDisconnect: () => {
+      console.warn('[summary-socket] disconnected from backend');
+    },
+    onEvent: event => {
+      console.log('[summary-socket] event received', event);
+      setSummaryStatusByLinkId(prev => ({
+        ...prev,
+        [event.linkId]: {
+          status: event.status,
+          progress: event.progress,
+          summary: event.summary,
+          errorMessage: event.errorMessage,
+        },
+      }));
+
+      // 요약 생성 시작 감지
+      if (event.status === 'generating') {
+        processingLinkIdsRef.current.add(event.linkId);
+        console.log('[summary-socket] tracking linkId', event.linkId);
+      }
+
+      // 요약 생성 완료/실패 감지 → 최종 상태 도달 시 refetch
+      if (event.status === 'ready' || event.status === 'failed') {
+        const wasProcessing = processingLinkIdsRef.current.has(event.linkId);
+        const isVisibleLink = links.some(link => link.id === event.linkId);
+
+        processingLinkIdsRef.current.delete(event.linkId);
+
+        if (wasProcessing || isVisibleLink) {
+          console.log('[summary-socket] linkId summary complete', {
+            linkId: event.linkId,
+            status: event.status,
+          });
+          console.log('[summary-socket] refetching after summary', event.linkId);
+          refetch();
+        }
+      }
+    },
+    onError: error => {
+      console.error('[summary-socket] error', {
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error,
+      });
+    },
+  });
+
   const {
     data: selectedLinkDetail,
     isLoading: isSelectedLinkLoading,
@@ -51,7 +117,13 @@ export default function AllLink() {
     refetch: refetchSelectedLink,
   } = useGetLink(isPanelOpen ? selectedLinkId : null);
 
-  const links = data?.pages.flatMap(page => page.content) ?? [];
+  const links = useMemo(() => data?.pages.flatMap(page => page.content) ?? [], [data]);
+
+  useEffect(() => {
+    processingLinkIdsRef.current = new Set(
+      links.filter(link => link.summaryStatus === 'generating').map(link => link.id)
+    );
+  }, [links]);
 
   const handleSelectLink = (id: number) => {
     selectLink(id);
@@ -126,19 +198,26 @@ export default function AllLink() {
                   isLoading={isFetchingNextPage}
                 >
                   <CardList>
-                    {links.map(link => (
-                      <LinkCard
-                        key={link.id}
-                        title={link.title}
-                        link={link.url}
-                        summary={link.summary ?? ''}
-                        imageUrl={link.imageUrl ?? ''}
-                        onClick={() => handleSelectLink(link.id)}
-                        selectable
-                        isSelected={selectedIds.has(link.id)}
-                        onSelect={() => handleToggleSelect(link.id)}
-                      />
-                    ))}
+                    {links.map(link => {
+                      const statusInfo = summaryStatusByLinkId[link.id];
+                      const summaryStatus = statusInfo?.status ?? link.summaryStatus ?? 'idle';
+                      const summaryText = statusInfo?.summary ?? link.summary ?? '';
+                      return (
+                        <LinkCard
+                          key={link.id}
+                          title={link.title}
+                          link={link.url}
+                          summary={summaryText}
+                          summaryStatus={summaryStatus}
+                          summaryErrorMessage={statusInfo?.errorMessage}
+                          imageUrl={link.imageUrl ?? ''}
+                          onClick={() => handleSelectLink(link.id)}
+                          selectable
+                          isSelected={selectedIds.has(link.id)}
+                          onSelect={() => handleToggleSelect(link.id)}
+                        />
+                      );
+                    })}
                   </CardList>
                 </InfiniteScroll>
               )}

--- a/src/components/basics/LinkCard/LinkCard.tsx
+++ b/src/components/basics/LinkCard/LinkCard.tsx
@@ -3,6 +3,7 @@
 import { getSafeUrl } from '@/hooks/util/getSafeUrl';
 import MarkdownRenderer from '@/hooks/util/parseMarkdown';
 import { useInteractiveKeyBlock } from '@/hooks/util/useInteractiveKeyBlock';
+import type { LinkSummaryStatus } from '@/types/link';
 import Image from 'next/image';
 import React from 'react';
 
@@ -17,6 +18,8 @@ interface LinkCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onCl
   link: string;
   summary: string;
   title: string;
+  summaryStatus?: LinkSummaryStatus;
+  summaryErrorMessage?: string;
   isSelected?: boolean;
   selectable?: boolean;
   onClick?: () => void;
@@ -28,6 +31,8 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
     imageUrl,
     link,
     summary,
+    summaryStatus = 'idle',
+    summaryErrorMessage,
     title,
     onClick,
     isSelected = false,
@@ -39,6 +44,21 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
 ) {
   const handleKeyDown = useInteractiveKeyBlock({ onClick });
   const safeHref = getSafeUrl(link);
+
+  const normalizedSummary = summary?.trim();
+  const isSummaryEmpty =
+    !normalizedSummary ||
+    normalizedSummary.toLowerCase() === 'null' ||
+    normalizedSummary.toLowerCase() === 'undefined';
+
+  const normalizedImageUrl =
+    imageUrl &&
+    imageUrl.trim() &&
+    imageUrl.trim().toLowerCase() !== 'null' &&
+    imageUrl.trim().toLowerCase() !== 'undefined'
+      ? imageUrl
+      : '';
+  const safeImageUrl = getSafeUrl(normalizedImageUrl) || '/images/default_linkcard_image.png';
 
   return (
     <div
@@ -81,18 +101,18 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
         </div>
       )}
 
-      {!summary && (
+      {(summaryStatus === 'generating' || summaryStatus === 'failed') && (
         <Badge
-          label="요약 실패"
-          icon="IC_Warning"
-          variant="warning"
+          label={summaryStatus === 'generating' ? '요약 생성 중' : '요약 실패'}
+          icon={summaryStatus === 'generating' ? 'IC_SumGenerate' : 'IC_Warning'}
+          variant={summaryStatus === 'generating' ? 'primary' : 'warning'}
           className="absolute top-2 left-2 z-10"
         />
       )}
 
       <div className="bg-gray900 relative aspect-94/47 w-full max-w-94 shrink-0">
         <Image
-          src={imageUrl ? imageUrl : '/images/default_linkcard_image.png'}
+          src={safeImageUrl}
           alt={title}
           fill
           sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
@@ -112,16 +132,52 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
             </Anchor>
           </div>
         </div>
-        {!!summary ? (
-          <MarkdownRenderer
-            className="text-etc-linkcard-summary font-body-sm line-clamp-2"
-            content={summary}
-          />
-        ) : (
-          <div className="font-body-sm text-etc-linkcard-summary flex justify-end">
-            <span>{SUMMARY_FAIL_TEXT}</span>
-          </div>
-        )}
+        {(() => {
+          if (summaryStatus === 'generating') {
+            return (
+              <div className="mt-[2.1875rem] flex flex-col gap-2">
+                <div className="bg-gray200 h-4 w-full rounded" />
+                <div className="bg-gray200 h-4 w-3/4 rounded" />
+              </div>
+            );
+          }
+
+          if (summaryStatus === 'failed') {
+            return (
+              <div className="font-body-sm text-etc-linkcard-summary flex justify-end">
+                <span>{summaryErrorMessage ?? SUMMARY_FAIL_TEXT}</span>
+              </div>
+            );
+          }
+
+          if (summaryStatus === 'ready') {
+            return !isSummaryEmpty ? (
+              <MarkdownRenderer
+                className="text-etc-linkcard-summary font-body-sm line-clamp-2"
+                content={summary}
+              />
+            ) : (
+              <div className="font-body-sm text-etc-linkcard-summary text-gray600">
+                <span>요약이 곧 도착합니다...</span>
+              </div>
+            );
+          }
+
+          if (!isSummaryEmpty) {
+            return (
+              <MarkdownRenderer
+                className="text-etc-linkcard-summary font-body-sm line-clamp-2"
+                content={summary}
+              />
+            );
+          }
+
+          return (
+            <div className="font-body-sm text-etc-linkcard-summary text-gray600 flex justify-end">
+              <span>요약이 아직 생성되지 않았습니다.</span>
+            </div>
+          );
+        })()}
       </div>
     </div>
   );

--- a/src/hooks/usePostLinks.ts
+++ b/src/hooks/usePostLinks.ts
@@ -13,7 +13,8 @@ export function usePostLinks({ skipInvalidate = false }: UsePostLinksOptions = {
     mutationFn: createLink,
     onSuccess: () => {
       if (!skipInvalidate) {
-        qc.invalidateQueries({ queryKey: ['links'] });
+        console.log('[usePostLinks] link created, refetching links');
+        qc.refetchQueries({ queryKey: ['links'] });
       }
     },
   });

--- a/src/hooks/useSummaryStatusSocket.ts
+++ b/src/hooks/useSummaryStatusSocket.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { type SummaryStatusEvent, createSummarySocket } from '@/apis/summarySocket';
+import { useEffect, useRef } from 'react';
+
+export type UseSummaryStatusSocketOptions = {
+  enabled?: boolean;
+  onEvent: (event: SummaryStatusEvent) => void;
+  onError?: (error: unknown) => void;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+  useSockJS?: boolean;
+};
+
+export const useSummaryStatusSocket = ({
+  enabled = true,
+  onEvent,
+  onError,
+  onConnect,
+  onDisconnect,
+  useSockJS = true,
+}: UseSummaryStatusSocketOptions) => {
+  const socketRef = useRef<ReturnType<typeof createSummarySocket> | null>(null);
+  const onEventRef = useRef(onEvent);
+  const onErrorRef = useRef(onError);
+  const onConnectRef = useRef(onConnect);
+  const onDisconnectRef = useRef(onDisconnect);
+
+  useEffect(() => {
+    onEventRef.current = onEvent;
+    onErrorRef.current = onError;
+    onConnectRef.current = onConnect;
+    onDisconnectRef.current = onDisconnect;
+  }, [onEvent, onError, onConnect, onDisconnect]);
+
+  useEffect(() => {
+    if (!enabled) {
+      socketRef.current?.disconnect();
+      socketRef.current = null;
+      return;
+    }
+
+    const socket = createSummarySocket({
+      useSockJS,
+      onEvent: event => onEventRef.current(event),
+      onError: error => onErrorRef.current?.(error),
+      onConnect: () => onConnectRef.current?.(),
+      onDisconnect: () => onDisconnectRef.current?.(),
+    });
+
+    socketRef.current = socket;
+    socket.connect();
+
+    return () => {
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [enabled, useSockJS]);
+};


### PR DESCRIPTION
## 관련 이슈

- close #465 

## PR 설명

- 수정 파일
  - src/apis/linkApi.ts
  - src/apis/summarySocket.ts
  - src/app/(route)/all-link/AllLink.tsx
  - src/components/basics/LinkCard/LinkCard.tsx
  - src/hooks/usePostLinks.ts
  - src/hooks/useSummaryStatusSocket.ts

- summarySocket.ts
  - STOMP WebSocket 연결 구현
  - SummaryStatusPayload → SummaryStatusEvent 변환 (PENDING/PROCESSING → generating, COMPLETED → ready, FAILED → failed)
  - parsePayload 유효성 검사 (linkId, status)
  - onWebSocketError, onStompError, onWebSocketClose 로그

- useSummaryStatusSocket.ts
  - hook 생성, 생성/연결/해제 관리
  - enabled, onEvent/onConnect/onDisconnect/onError 옵션

- AllLink.tsx
  - useSummaryStatusSocket 연동
  - state summaryStatusByLinkId 저장
  - generating 시작/완료 감지 후 processingLinkIdsRef 관리
  - ready/failed 시 refetch
  - summaryStatus fallback: statusInfo > link.summaryStatus > link.summary 여부(ready/failed 또는 idle)
  - LinkCard에 summaryStatus, summaryErrorMessage 전달

- LinkCard.tsx
  - summaryStatus별 표시
    - generating → skeleton 2줄
    - failed → 배지 + 실패 문구
    - ready → summary markdown
    - idle/미생성 → 요약 대기 문구
  - null/undefined summary 값 처리
  - imageUrl 유효검사 후 기본/실제 URL

- usePostLinks.ts
  - 성공 시 refetchQueries(['links'])

- linkApi.ts
  - normalizeLink에 summaryStatus/summaryProgress/summaryUpdatedAt 포함
