### PR TITLE
채팅 연속 전송 비활성화

### DIFF
--- a/src/apis/chatSocket.ts
+++ b/src/apis/chatSocket.ts
@@ -70,6 +70,7 @@ export type ChatSocketMessage = {
   chatId: number;
   messageId: number | null;
   content: string;
+  isEnd: boolean;
   step: string | string[] | null;
   links: ChatSocketLink[] | null;
 };
@@ -166,6 +167,7 @@ const parseIncomingMessage = (rawBody: string): ChatSocketMessage => {
 
   const content = typeof data.content === 'string' ? data.content : '';
   const messageId = toNumberOrNull(data.messageId);
+  const isEnd = typeof data.isEnd === 'boolean' ? data.isEnd : false;
   const step = toStepOrNull(data.step);
   const links = toLinksOrNull(data.links);
 
@@ -174,6 +176,7 @@ const parseIncomingMessage = (rawBody: string): ChatSocketMessage => {
     chatId,
     messageId,
     content,
+    isEnd,
     step,
     links,
   };

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -4,6 +4,7 @@ import { addMessageFeedback, fetchChatMessages } from '@/apis/chatApi';
 import type { ChatSocketLink, ChatSocketMessage } from '@/apis/chatSocket';
 import CardList from '@/components/basics/CardList/CardList';
 import LinkCard from '@/components/basics/LinkCard/LinkCard';
+import Spinner from '@/components/basics/Spinner/Spinner';
 import Tab from '@/components/basics/Tab/Tab';
 import CopyButton from '@/components/wrappers/CopyButton';
 import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
@@ -12,7 +13,7 @@ import { useChatStream } from '@/hooks/server/Chats/useChatStream';
 import { useModalStore } from '@/stores/modalStore';
 import { showToast } from '@/stores/toastStore';
 import type { ChatHistoryMessage } from '@/types/api/chatApi';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import AnswerActions, { type AnswerReaction } from '../_components/AnswerActions';
@@ -28,6 +29,7 @@ type ChatMessage = {
 };
 
 const PAGE_SIZE = 5;
+const RESPONSE_IDLE_UNLOCK_MS = 500;
 
 const toLinks = (links: ChatHistoryMessage['links']): ChatSocketLink[] | null => {
   if (!links || links.length === 0) return null;
@@ -67,7 +69,6 @@ const mergeAiText = (prevText: string, nextText: string) => {
 
 export default function Chat() {
   const params = useParams();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const chatId = useMemo(() => (typeof params?.id === 'string' ? params.id : ''), [params]);
   const chatIdNum = useMemo(() => Number(chatId), [chatId]);
@@ -77,6 +78,7 @@ export default function Chat() {
   const openModal = useModalStore(state => state.open);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
   const [streamError, setStreamError] = useState<string | null>(null);
   const [selectedLink, setSelectedLink] = useState<ChatSocketLink | null>(null);
   const [historyCursor, setHistoryCursor] = useState<number | null>(null);
@@ -89,6 +91,21 @@ export default function Chat() {
   const olderHistoryInFlightRef = useRef(false);
   const historyRequestSeqRef = useRef(0);
   const reactionRequestSeqRef = useRef<Record<string, number>>({});
+  const responseUnlockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearResponseUnlockTimer = useCallback(() => {
+    if (!responseUnlockTimerRef.current) return;
+    clearTimeout(responseUnlockTimerRef.current);
+    responseUnlockTimerRef.current = null;
+  }, []);
+
+  const scheduleResponseUnlock = useCallback(() => {
+    clearResponseUnlockTimer();
+    responseUnlockTimerRef.current = setTimeout(() => {
+      setIsAwaitingResponse(false);
+      responseUnlockTimerRef.current = null;
+    }, RESPONSE_IDLE_UNLOCK_MS);
+  }, [clearResponseUnlockTimer]);
 
   const appendAiMessage = useCallback((payload: ChatSocketMessage) => {
     setMessages(prev => {
@@ -169,11 +186,28 @@ export default function Chat() {
       if (String(payload.chatId) !== chatId) return;
 
       if (payload.success) {
-        appendAiMessage(payload);
         setStreamError(null);
+        const hasContent = Boolean(payload.content);
+        const hasLinks = Boolean(payload.links?.length);
+
+        if (payload.isEnd && !hasContent && !hasLinks) {
+          clearResponseUnlockTimer();
+          setIsAwaitingResponse(false);
+          return;
+        }
+
+        appendAiMessage(payload);
+        if (payload.isEnd) {
+          clearResponseUnlockTimer();
+          setIsAwaitingResponse(false);
+        } else {
+          scheduleResponseUnlock();
+        }
         return;
       }
 
+      clearResponseUnlockTimer();
+      setIsAwaitingResponse(false);
       setStreamError('답변 생성에 실패했습니다.');
       setMessages(prev => [
         ...prev,
@@ -189,17 +223,22 @@ export default function Chat() {
       setStreamError(null);
       if (!initialQuestion || initialSentRef.current) return;
       initialSentRef.current = true;
+      setIsAwaitingResponse(true);
       setMessages(prev => [
         ...prev,
         { id: `${Date.now()}-${crypto.randomUUID()}`, role: 'user', text: initialQuestion },
       ]);
       send(initialQuestion);
-      router.replace(`/chat/${chatId}`);
+      window.history.replaceState(window.history.state, '', `/chat/${chatId}`);
     },
     onDisconnect: () => {
+      clearResponseUnlockTimer();
+      setIsAwaitingResponse(false);
       setStreamError('소켓 연결이 종료되었습니다.');
     },
     onError: (err: unknown) => {
+      clearResponseUnlockTimer();
+      setIsAwaitingResponse(false);
       setStreamError((err as Error).message ?? '소켓 연결 중 오류가 발생했습니다.');
     },
   });
@@ -293,13 +332,22 @@ export default function Chat() {
     historyRequestSeqRef.current += 1;
     olderHistoryInFlightRef.current = false;
     initialSentRef.current = false;
+    clearResponseUnlockTimer();
     setStreamError(null);
+    setIsAwaitingResponse(false);
     setSelectedLink(null);
     setMessages([]);
     setHistoryCursor(null);
     setHistoryHasNext(false);
     void loadInitialHistory();
-  }, [chatId, loadInitialHistory]);
+  }, [chatId, clearResponseUnlockTimer, loadInitialHistory]);
+
+  useEffect(
+    () => () => {
+      clearResponseUnlockTimer();
+    },
+    [clearResponseUnlockTimer]
+  );
 
   useEffect(() => {
     const adjust = pendingScrollAdjustRef.current;
@@ -319,10 +367,13 @@ export default function Chat() {
       setStreamError('소켓이 연결되지 않았습니다.');
       return;
     }
+    if (isAwaitingResponse) return;
 
     const trimmedValue = value.trim();
     if (!trimmedValue) return;
 
+    setIsAwaitingResponse(true);
+    clearResponseUnlockTimer();
     setMessages(prev => [
       ...prev,
       { id: `${Date.now()}-${crypto.randomUUID()}`, role: 'user', text: trimmedValue },
@@ -331,6 +382,8 @@ export default function Chat() {
     try {
       send(trimmedValue);
     } catch (err) {
+      clearResponseUnlockTimer();
+      setIsAwaitingResponse(false);
       setStreamError((err as Error).message ?? '메시지 전송에 실패했습니다.');
     }
   };
@@ -534,13 +587,22 @@ export default function Chat() {
                   )}
                 </div>
               ))}
+
+              {isAwaitingResponse && (
+                <div className="flex justify-start">
+                  <div className="flex items-center gap-2 px-3 py-2">
+                    <Spinner width={18} height={18} />
+                    <span className="font-body-md text-gray500">답변을 생성하고 있어요.</span>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </div>
 
         <div className="absolute bottom-0 left-0 z-10 mb-15 flex w-full justify-center px-4">
           <div className="w-full max-w-[816px] shrink-0">
-            <ChatQueryBox onSubmit={handleSubmit} disabled={!connected} />
+            <ChatQueryBox onSubmit={handleSubmit} disabled={!connected || isAwaitingResponse} />
           </div>
         </div>
       </div>

--- a/src/app/(route)/chat/_components/ChatQueryBox.tsx
+++ b/src/app/(route)/chat/_components/ChatQueryBox.tsx
@@ -6,10 +6,12 @@ import { useState } from 'react';
 interface ChatQueryBoxProps {
   onSubmit: (value: string) => void;
   disabled?: boolean;
+  inputDisabled?: boolean;
 }
 
-const ChatQueryBox = ({ onSubmit, disabled = false }: ChatQueryBoxProps) => {
+const ChatQueryBox = ({ onSubmit, disabled = false, inputDisabled = false }: ChatQueryBoxProps) => {
   const [value, setValue] = useState('');
+
   const handleSubmit = () => {
     const nextValue = value.trim();
     if (!nextValue || disabled) return;
@@ -17,7 +19,15 @@ const ChatQueryBox = ({ onSubmit, disabled = false }: ChatQueryBoxProps) => {
     setValue('');
   };
 
-  return <QueryBox value={value} onChange={setValue} onSubmit={handleSubmit} />;
+  return (
+    <QueryBox
+      value={value}
+      onChange={setValue}
+      onSubmit={handleSubmit}
+      disabled={disabled}
+      inputDisabled={inputDisabled}
+    />
+  );
 };
 
 export default ChatQueryBox;

--- a/src/app/(route)/home/HomePage.tsx
+++ b/src/app/(route)/home/HomePage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Spinner from '@/components/basics/Spinner/Spinner';
+import CopyButton from '@/components/wrappers/CopyButton';
 import { useState } from 'react';
 
 import ChatQueryBox from '../chat/_components/ChatQueryBox';
@@ -18,9 +19,20 @@ export default function Home() {
     return (
       <div className="relative flex h-screen w-full justify-center">
         <div className="relative flex h-full w-full max-w-[816px] flex-1 flex-col px-4">
-          <span className="bg-blue50 absolute top-6 right-0 max-w-[70%] rounded-2xl px-4 py-3 whitespace-pre-wrap">
-            {form.firstChat}
-          </span>
+          <div className="absolute top-6 right-0 max-w-[70%]">
+            <span className="bg-blue50 block rounded-2xl px-4 py-3 whitespace-pre-wrap">
+              {form.firstChat}
+            </span>
+            <div className="mt-2 flex justify-end">
+              <CopyButton
+                value={form.firstChat}
+                successMsg="질문을 복사했습니다."
+                failMsg="질문 복사에 실패했습니다."
+                tooltipMsg="질문 복사하기"
+                size="sm"
+              />
+            </div>
+          </div>
           <div className="absolute top-20 left-0 mx-4 mt-6 flex items-center justify-center gap-2 px-4 py-3">
             <Spinner width={18} height={18} />
             <span className="font-body-md text-gray500">답변을 생성하고 있어요.</span>

--- a/src/components/wrappers/QueryBox.tsx
+++ b/src/components/wrappers/QueryBox.tsx
@@ -7,9 +7,17 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   onSubmit: () => void;
+  disabled?: boolean;
+  inputDisabled?: boolean;
 }
 
-export default function QueryBox({ value, onChange, onSubmit }: Props) {
+export default function QueryBox({
+  value,
+  onChange,
+  onSubmit,
+  disabled = false,
+  inputDisabled = false,
+}: Props) {
   return (
     <div className="relative w-full">
       <TextArea
@@ -21,9 +29,10 @@ export default function QueryBox({ value, onChange, onSubmit }: Props) {
         value={value}
         onChange={e => onChange(e.target.value)}
         onSubmit={onSubmit}
+        disabled={inputDisabled}
         className="shadow-[0_2px_4px_rgba(0,0,0,0.04),0_4px_8px_rgba(0,0,0,0.04)]"
       />
-      <SendButton disabled={!value.trim()} onClick={onSubmit} />
+      <SendButton disabled={disabled || !value.trim()} onClick={onSubmit} />
     </div>
   );
 }


### PR DESCRIPTION
## 관련 이슈

- close #473

## PR 설명

채팅 페이지에서 답변 수신 중 연속 전송이 가능하던 문제를 수정했습니다.

- `src/app/(route)/chat/[id]/ChatPage.tsx`
  - 답변 대기 상태(`isAwaitingResponse`)를 추가했습니다.
  - 답변 생성 중에는 추가 질문을 보내지 못하도록 제어했습니다.
  - 응답 대기 중 `답변을 생성하고 있어요.` 로딩 UI가 보이도록 추가했습니다.
  - 홈에서 첫 질문 후 진입할 때 `router.replace` 대신 `history.replaceState`를 사용하도록 바꿔 화면이 다시 로드되는 느낌을 줄였습니다.
  - 소켓 종료 신호가 명확하지 않은 경우를 대비해 마지막 응답 이후 0.5초 동안 추가 응답이 없으면 다시 전송 가능 상태가 되도록 처리했습니다.

- `src/apis/chatSocket.ts`
  - 소켓 응답 payload에서 `isEnd` 값을 파싱하도록 수정했습니다.
  - 채팅 페이지가 응답 완료 여부를 더 정확하게 판단할 수 있도록 타입과 파싱 로직을 보완했습니다.

- `src/components/wrappers/QueryBox.tsx`
  - QueryBox의 비활성화 동작을 분리했습니다.
  - 입력창 전체를 막는 방식이 아니라, 전송 버튼만 비활성화할 수 있도록 `disabled`와 `inputDisabled` 역할을 나눴습니다.

- `src/app/(route)/chat/_components/ChatQueryBox.tsx`
  - QueryBox 변경에 맞춰 `inputDisabled`를 받을 수 있도록 수정했습니다.
  - 채팅 페이지에서는 입력은 가능하고 전송 버튼만 막히는 동작을 적용할 수 있게 연결했습니다.

- `src/app/(route)/home/HomePage.tsx`
  - 홈에서 첫 질문 전송 후 대기 화면에도 첫 질문 복사 버튼이 바로 보이도록 수정했습니다.
  - 홈에서 채팅방 생성 중일 때도 입력창은 유지하고, 전송 버튼만 비활성화되도록 동작을 맞췄습니다.
