### PR TITLE
사이드패널 유저정보 디자인 수정

### DIFF
--- a/src/components/layout/SideNavigation/components/Bottom/SideNavigationBottom.tsx
+++ b/src/components/layout/SideNavigation/components/Bottom/SideNavigationBottom.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/basics/Button/Button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/basics/Popover';
+import Spinner from '@/components/basics/Spinner/Spinner';
 import { useLogout } from '@/hooks/useLogout';
 import { useUserInfo } from '@/hooks/useUserInfo';
 
@@ -9,7 +10,11 @@ const SideNavigationBottom = () => {
   const { data: user, isLoading } = useUserInfo();
   const { mutate: handleLogout, isPending: isLoggingOut } = useLogout();
   if (isLoading) {
-    return <div className="bg-gray50 mt-auto shrink-0 p-5">로딩 중...</div>;
+    return (
+      <div className="flex shrink-0 items-center justify-center p-2">
+        <Spinner />
+      </div>
+    );
   }
 
   return (

--- a/src/components/layout/SideNavigation/components/NavItem/NavItem.tsx
+++ b/src/components/layout/SideNavigation/components/NavItem/NavItem.tsx
@@ -1,5 +1,6 @@
+import SVGIcon from '@/components/Icons/SVGIcon';
 import { IconMapTypes } from '@/components/Icons/icons';
-import Button, { ButtonProps } from '@/components/basics/Button/Button';
+import { ButtonProps } from '@/components/basics/Button/Button';
 import IconButton from '@/components/basics/IconButton/IconButton';
 import { useBlurOnClick } from '@/hooks/util/useBlurOnClick';
 import { useSideNavStore } from '@/stores/sideNavStore';
@@ -26,15 +27,16 @@ const NavItem = forwardRef<HTMLButtonElement, NavItemProps>(
     };
 
     return isOpen ? (
-      <Button
-        {...commonProps}
-        icon={icon}
-        radius="full"
-        className="flex h-10! w-50 justify-start gap-2 pl-2"
+      <button
         ref={mergedRef}
-        label={label}
+        className="group text-gray500 hover:text-gray700 bg-btn-tertiary-subtle-onpanel flex h-10 w-50 cursor-pointer items-center gap-2 rounded-full pr-3 pl-2 transition-colors"
         onClick={blurOnClick}
-      />
+        type="button"
+        aria-label={ariaLabel}
+      >
+        <SVGIcon icon={icon} aria-label={ariaLabel} size="xl" aria-hidden="true" />
+        <span className="font-label-lg truncate">{label}</span>
+      </button>
     ) : (
       <IconButton
         {...commonProps}


### PR DESCRIPTION
## 관련 이슈

- close #472

## PR 설명
- 아이콘과 유저명(현재 이메일) gap 1 → 2로 수정
- `truncate` 적용
- `로딩 중...` 텍스트 `Spinner` 컴포넌트로 변경