### PR TITLE
Feat: Add summary status sync fallback (#478)

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -1,4 +1,5 @@
 import { clientApiClient } from '@/lib/client/apiClient';
+import { ApiError } from '@/lib/errors/ApiError';
 import type {
   DeleteLinkApiResponse,
   DuplicateLinkApiResponse,
@@ -7,14 +8,70 @@ import type {
   LinkListApiResponse,
   LinkListViewData,
   LinkMetaScrapeApiResponse,
+  LinkSummaryStatusApiResponse,
+  LinkSummaryStatusData,
+  SummaryStatusResponse,
 } from '@/types/api/linkApi';
-import type { CreateLinkPayload, Link, UpdateLinkPayload } from '@/types/link';
+import type { CreateLinkPayload, Link, LinkSummaryStatus, UpdateLinkPayload } from '@/types/link';
 
 const LINKS_BFF = '/api/links';
 
 export type LinkListParams = {
   lastId?: number | null;
   size?: number;
+};
+
+const RAW_TO_LINK_SUMMARY_STATUS: Record<SummaryStatusResponse, LinkSummaryStatus> = {
+  PENDING: 'generating',
+  PROCESSING: 'generating',
+  COMPLETED: 'ready',
+  FAILED: 'failed',
+};
+
+const isRawSummaryStatus = (value: unknown): value is SummaryStatusResponse =>
+  typeof value === 'string' &&
+  Object.prototype.hasOwnProperty.call(RAW_TO_LINK_SUMMARY_STATUS, value);
+
+const isLinkSummaryStatus = (value: unknown): value is LinkSummaryStatus =>
+  value === 'idle' || value === 'generating' || value === 'ready' || value === 'failed';
+
+const hasText = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+export const resolveSummaryContent = (
+  rawSummary: { id?: number; content?: string } | string | null | undefined
+): string => {
+  if (rawSummary !== null && typeof rawSummary === 'object') {
+    return typeof rawSummary.content === 'string' ? rawSummary.content : '';
+  }
+
+  return typeof rawSummary === 'string' ? rawSummary : '';
+};
+
+export const normalizeLinkSummaryStatus = (
+  rawStatus: unknown,
+  summary: string | null | undefined,
+  errorMessage?: string | null
+): LinkSummaryStatus => {
+  if (isLinkSummaryStatus(rawStatus)) return rawStatus;
+  if (isRawSummaryStatus(rawStatus)) return RAW_TO_LINK_SUMMARY_STATUS[rawStatus];
+  if (hasText(errorMessage)) return 'failed';
+  if (hasText(summary)) return 'ready';
+  return 'idle';
+};
+
+const resolveInitialLinkSummaryStatus = (
+  rawStatus: unknown,
+  summary: string,
+  errorMessage?: string | null
+): LinkSummaryStatus | undefined => {
+  if (isLinkSummaryStatus(rawStatus) || isRawSummaryStatus(rawStatus)) {
+    return normalizeLinkSummaryStatus(rawStatus, summary, errorMessage);
+  }
+
+  if (hasText(errorMessage)) return 'failed';
+  if (hasText(summary)) return 'ready';
+  return undefined;
 };
 
 function buildQuery(params?: LinkListParams) {
@@ -28,15 +85,29 @@ function buildQuery(params?: LinkListParams) {
   return qs ? `?${qs}` : '';
 }
 
-const normalizeLink = (
-  data: Partial<Omit<Link, 'summary'>> & { summary?: { id: number; content: string } | string }
-): Link => {
+type LinkSource = {
+  id?: number;
+  url?: string;
+  title?: string;
+  summary?: { id: number; content: string } | string | null;
+  summaryStatus?: unknown;
+  summaryErrorMessage?: string | null;
+  summaryProgress?: number | null;
+  summaryUpdatedAt?: string | null;
+  memo?: string | null;
+  imageUrl?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+const normalizeLink = (data: LinkSource): Link => {
   const now = new Date().toISOString();
-  const rawSummary = data.summary;
-  const summary =
-    rawSummary !== null && typeof rawSummary === 'object'
-      ? (rawSummary as { id: number; content: string }).content
-      : (rawSummary ?? '');
+  const summary = resolveSummaryContent(data.summary);
+  const summaryStatus = resolveInitialLinkSummaryStatus(
+    data.summaryStatus,
+    summary,
+    data.summaryErrorMessage
+  );
 
   return {
     id: data.id ?? 0,
@@ -47,9 +118,9 @@ const normalizeLink = (
     imageUrl: data.imageUrl ?? '',
     createdAt: data.createdAt ?? now,
     updatedAt: data.updatedAt ?? now,
-    summaryStatus: data.summaryStatus,
-    summaryProgress: data.summaryProgress,
-    summaryUpdatedAt: data.summaryUpdatedAt,
+    summaryStatus,
+    summaryProgress: typeof data.summaryProgress === 'number' ? data.summaryProgress : undefined,
+    summaryUpdatedAt: data.summaryUpdatedAt ?? undefined,
   };
 };
 
@@ -177,4 +248,26 @@ export const scrapeLinkMeta = async (url: string) => {
   }
 
   return response.data;
+};
+
+export const fetchLinkSummaryStatus = async (id: number): Promise<LinkSummaryStatusData> => {
+  const body = await clientApiClient<LinkSummaryStatusApiResponse>(
+    `/api/links/${id}/summary-status`,
+    {
+      method: 'GET',
+    }
+  );
+
+  if (!body?.data || !body.success) {
+    const status =
+      typeof body?.status === 'number'
+        ? body.status
+        : typeof body?.status === 'string' && Number.isFinite(Number(body.status))
+          ? Number(body.status)
+          : 500;
+
+    throw new ApiError(status, body?.message ?? 'Invalid response', body);
+  }
+
+  return body.data;
 };

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import {
+  fetchLinkSummaryStatus,
+  normalizeLinkSummaryStatus,
+  resolveSummaryContent,
+} from '@/apis/linkApi';
 import Button from '@/components/basics/Button/Button';
 import InfiniteScroll from '@/components/basics/InfiniteScroll/InfiniteScroll';
 import LinkCard from '@/components/basics/LinkCard/LinkCard';
@@ -10,11 +15,66 @@ import { useGetInfiniteLinks } from '@/hooks/useGetInfiniteLinks';
 import { useGetLink } from '@/hooks/useGetLink';
 import useLinkCount from '@/hooks/useGetLinksCount';
 import { useSummaryStatusSocket } from '@/hooks/useSummaryStatusSocket';
+import { ApiError } from '@/lib/errors/ApiError';
 import { useLinkStore } from '@/stores/linkStore';
 import { useModalStore } from '@/stores/modalStore';
 import type { LinkSummaryStatus } from '@/types/link';
 import { type Link } from '@/types/link';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type SummaryStatusInfo = {
+  status: LinkSummaryStatus;
+  progress?: number;
+  summary?: string;
+  errorMessage?: string;
+};
+
+const STATUS_POLL_INTERVAL_MS = 5000;
+const MAX_GENERATING_POLL_ATTEMPTS = 36;
+const MAX_GENERATING_STAGNANT_POLLS = 6;
+const hasSummaryText = (summary: string): boolean => summary.trim().length > 0;
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const getErrorStatus = (error: unknown): number | null => {
+  if (!error || typeof error !== 'object' || !('status' in error)) return null;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
+};
+
+const isRetryableSummaryStatusError = (error: unknown): boolean => {
+  const status = error instanceof ApiError ? error.status : getErrorStatus(error);
+  if (status !== null) return RETRYABLE_STATUS_CODES.has(status);
+  return true;
+};
+
+type GeneratingPollSnapshot = {
+  progress?: number;
+  updatedAt?: string;
+  stagnantCount: number;
+};
+
+const resolveLinkSummaryStatus = (
+  link: Link,
+  statusInfo?: SummaryStatusInfo
+): LinkSummaryStatus | undefined => {
+  const summaryText = statusInfo?.summary ?? link.summary ?? '';
+  const errorMessage = statusInfo?.errorMessage;
+
+  if (statusInfo?.status) return statusInfo.status;
+  if (link.summaryStatus !== undefined) {
+    return normalizeLinkSummaryStatus(link.summaryStatus, summaryText, errorMessage);
+  }
+  if (typeof errorMessage === 'string' && errorMessage.trim()) return 'failed';
+  if (hasSummaryText(summaryText)) return 'ready';
+
+  return undefined;
+};
+
+const toPanelSummaryState = (status: LinkSummaryStatus): 'idle' | 'loading' | 'error' | 'ready' => {
+  if (status === 'generating') return 'loading';
+  if (status === 'failed') return 'error';
+  if (status === 'ready') return 'ready';
+  return 'idle';
+};
 
 const LinkCardItem = memo(
   function LinkCardItem({
@@ -65,17 +125,10 @@ const LinkCardItem = memo(
 export default function AllLink() {
   const { selectedLinkId, selectLink } = useLinkStore();
   const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [isSocketConnected, setIsSocketConnected] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [summaryStatusByLinkId, setSummaryStatusByLinkId] = useState<
-    Record<
-      number,
-      {
-        status: LinkSummaryStatus;
-        progress?: number;
-        summary?: string;
-        errorMessage?: string;
-      }
-    >
+    Record<number, SummaryStatusInfo>
   >({});
   const { modal, open } = useModalStore();
 
@@ -84,7 +137,14 @@ export default function AllLink() {
 
   const { count } = useLinkCount();
   const processingLinkIdsRef = useRef<Set<number>>(new Set());
-  const linksRef = useRef<Link[]>([]); // ✅ 정상 위치
+  const polledUnknownLinkIdsRef = useRef<Set<number>>(new Set());
+  const nonRetryablePollLinkIdsRef = useRef<Set<number>>(new Set());
+  const generatingPollAttemptsRef = useRef<Map<number, number>>(new Map());
+  const generatingPollSnapshotsRef = useRef<Map<number, GeneratingPollSnapshot>>(new Map());
+  const exhaustedGeneratingLinkIdsRef = useRef<Set<number>>(new Set());
+  const linksRef = useRef<Link[]>([]);
+  const summaryStatusByLinkIdRef = useRef<Record<number, SummaryStatusInfo>>({});
+  const selectedLinkIdRef = useRef<number | null>(selectedLinkId);
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useGetInfiniteLinks();
@@ -96,12 +156,65 @@ export default function AllLink() {
     linksRef.current = links;
   }, [links]);
 
-  // ✅ generating 상태 추적
+  useEffect(() => {
+    const visibleLinkIds = new Set(links.map(link => link.id));
+
+    polledUnknownLinkIdsRef.current.forEach(linkId => {
+      if (!visibleLinkIds.has(linkId)) {
+        polledUnknownLinkIdsRef.current.delete(linkId);
+      }
+    });
+
+    nonRetryablePollLinkIdsRef.current.forEach(linkId => {
+      if (!visibleLinkIds.has(linkId)) {
+        nonRetryablePollLinkIdsRef.current.delete(linkId);
+      }
+    });
+
+    generatingPollAttemptsRef.current.forEach((_value, linkId) => {
+      if (!visibleLinkIds.has(linkId)) {
+        generatingPollAttemptsRef.current.delete(linkId);
+      }
+    });
+
+    generatingPollSnapshotsRef.current.forEach((_value, linkId) => {
+      if (!visibleLinkIds.has(linkId)) {
+        generatingPollSnapshotsRef.current.delete(linkId);
+      }
+    });
+
+    exhaustedGeneratingLinkIdsRef.current.forEach(linkId => {
+      if (!visibleLinkIds.has(linkId)) {
+        exhaustedGeneratingLinkIdsRef.current.delete(linkId);
+      }
+    });
+  }, [links]);
+
+  useEffect(() => {
+    polledUnknownLinkIdsRef.current.clear();
+    nonRetryablePollLinkIdsRef.current.clear();
+    generatingPollAttemptsRef.current.clear();
+    generatingPollSnapshotsRef.current.clear();
+    exhaustedGeneratingLinkIdsRef.current.clear();
+  }, [isSocketConnected]);
+
+  useEffect(() => {
+    summaryStatusByLinkIdRef.current = summaryStatusByLinkId;
+  }, [summaryStatusByLinkId]);
+
+  useEffect(() => {
+    selectedLinkIdRef.current = selectedLinkId;
+  }, [selectedLinkId]);
+
   useEffect(() => {
     processingLinkIdsRef.current = new Set(
-      links.filter(link => link.summaryStatus === 'generating').map(link => link.id)
+      links
+        .filter(
+          link => resolveLinkSummaryStatus(link, summaryStatusByLinkId[link.id]) === 'generating'
+        )
+        .map(link => link.id)
     );
-  }, [links]);
+  }, [links, summaryStatusByLinkId]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -120,18 +233,44 @@ export default function AllLink() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [modal.type]);
 
+  const {
+    data: selectedLinkDetail,
+    isLoading: isSelectedLinkLoading,
+    isError: isSelectedLinkError,
+    refetch: refetchSelectedLink,
+  } = useGetLink(isPanelOpen ? selectedLinkId : null);
+
   useSummaryStatusSocket({
     enabled: true,
+    onConnect: () => {
+      setIsSocketConnected(true);
+    },
+    onDisconnect: () => {
+      setIsSocketConnected(false);
+    },
+    onError: () => {
+      setIsSocketConnected(false);
+    },
     onEvent: event => {
-      setSummaryStatusByLinkId(prev => ({
-        ...prev,
-        [event.linkId]: {
-          status: event.status,
-          progress: event.progress,
-          summary: event.summary,
-          errorMessage: event.errorMessage,
-        },
-      }));
+      polledUnknownLinkIdsRef.current.delete(event.linkId);
+      nonRetryablePollLinkIdsRef.current.delete(event.linkId);
+      generatingPollAttemptsRef.current.delete(event.linkId);
+      generatingPollSnapshotsRef.current.delete(event.linkId);
+      exhaustedGeneratingLinkIdsRef.current.delete(event.linkId);
+
+      setSummaryStatusByLinkId(prev => {
+        const previous = prev[event.linkId];
+
+        return {
+          ...prev,
+          [event.linkId]: {
+            status: event.status,
+            progress: event.progress ?? previous?.progress,
+            summary: event.summary ?? previous?.summary,
+            errorMessage: event.errorMessage ?? previous?.errorMessage,
+          },
+        };
+      });
 
       if (event.status === 'generating') {
         processingLinkIdsRef.current.add(event.linkId);
@@ -144,18 +283,231 @@ export default function AllLink() {
         processingLinkIdsRef.current.delete(event.linkId);
 
         if (wasProcessing || isVisibleLink) {
-          refetch();
+          void refetch();
+        }
+
+        if (selectedLinkIdRef.current === event.linkId) {
+          void refetchSelectedLink();
         }
       }
     },
   });
 
-  const {
-    data: selectedLinkDetail,
-    isLoading: isSelectedLinkLoading,
-    isError: isSelectedLinkError,
-    refetch: refetchSelectedLink,
-  } = useGetLink(isPanelOpen ? selectedLinkId : null);
+  useEffect(() => {
+    if (isSocketConnected) return;
+
+    let cancelled = false;
+    let inFlight = false;
+
+    const pollSummaryStatus = async () => {
+      if (cancelled || inFlight) return;
+
+      const linksSnapshot = linksRef.current;
+      const statusSnapshot = summaryStatusByLinkIdRef.current;
+      const targetModes = new Map<number, 'generating' | 'unknown'>();
+      const targetIds: number[] = [];
+
+      for (const link of linksSnapshot) {
+        if (nonRetryablePollLinkIdsRef.current.has(link.id)) continue;
+        if (exhaustedGeneratingLinkIdsRef.current.has(link.id)) continue;
+
+        const statusInfo = statusSnapshot[link.id];
+        const summaryText = statusInfo?.summary ?? link.summary ?? '';
+        if (hasSummaryText(summaryText)) {
+          generatingPollAttemptsRef.current.delete(link.id);
+          generatingPollSnapshotsRef.current.delete(link.id);
+          exhaustedGeneratingLinkIdsRef.current.delete(link.id);
+          continue;
+        }
+
+        const resolvedStatus = resolveLinkSummaryStatus(link, statusInfo);
+        if (resolvedStatus === 'generating') {
+          const currentAttempts = generatingPollAttemptsRef.current.get(link.id) ?? 0;
+          if (currentAttempts >= MAX_GENERATING_POLL_ATTEMPTS) {
+            exhaustedGeneratingLinkIdsRef.current.add(link.id);
+            continue;
+          }
+
+          targetModes.set(link.id, 'generating');
+          targetIds.push(link.id);
+          continue;
+        }
+
+        if (resolvedStatus !== undefined) continue;
+        if (polledUnknownLinkIdsRef.current.has(link.id)) continue;
+
+        polledUnknownLinkIdsRef.current.add(link.id);
+        targetModes.set(link.id, 'unknown');
+        targetIds.push(link.id);
+      }
+
+      if (targetIds.length === 0) return;
+
+      inFlight = true;
+      try {
+        const results = await Promise.all(
+          targetIds.map(async linkId => {
+            try {
+              const data = await fetchLinkSummaryStatus(linkId);
+              return { linkId, data, retryable: false };
+            } catch (error) {
+              return {
+                linkId,
+                data: null,
+                retryable: isRetryableSummaryStatusError(error),
+              };
+            }
+          })
+        );
+
+        if (cancelled) return;
+
+        let shouldRefetchLinks = false;
+        let shouldRefetchSelectedLink = false;
+        const summaryUpdates: Array<{
+          linkId: number;
+          data: NonNullable<Awaited<ReturnType<typeof fetchLinkSummaryStatus>>>;
+          status: LinkSummaryStatus;
+          summaryText: string;
+        }> = [];
+
+        for (const result of results) {
+          if (result.data) {
+            const summaryText = resolveSummaryContent(result.data.summary);
+            const status = normalizeLinkSummaryStatus(
+              result.data.status,
+              summaryText,
+              result.data.errorMessage
+            );
+
+            nonRetryablePollLinkIdsRef.current.delete(result.linkId);
+
+            if (targetModes.get(result.linkId) === 'generating' && status === 'generating') {
+              const currentAttempts = generatingPollAttemptsRef.current.get(result.linkId) ?? 0;
+              generatingPollAttemptsRef.current.set(result.linkId, currentAttempts + 1);
+            }
+
+            summaryUpdates.push({
+              linkId: result.linkId,
+              data: result.data,
+              summaryText,
+              status,
+            });
+            continue;
+          }
+
+          if (result.retryable) {
+            if (targetModes.get(result.linkId) === 'unknown') {
+              polledUnknownLinkIdsRef.current.delete(result.linkId);
+            }
+
+            const attempts = generatingPollAttemptsRef.current.get(result.linkId) ?? 0;
+            if (attempts >= MAX_GENERATING_POLL_ATTEMPTS) {
+              exhaustedGeneratingLinkIdsRef.current.add(result.linkId);
+            }
+            continue;
+          }
+
+          nonRetryablePollLinkIdsRef.current.add(result.linkId);
+        }
+
+        for (const { linkId, data, status } of summaryUpdates) {
+          if (status === 'generating') {
+            processingLinkIdsRef.current.add(linkId);
+
+            const previousSnapshot = generatingPollSnapshotsRef.current.get(linkId);
+            const currentProgress =
+              typeof data.progress === 'number' ? data.progress : previousSnapshot?.progress;
+            const currentUpdatedAt =
+              typeof data.updatedAt === 'string' ? data.updatedAt : undefined;
+            const hasProgressChanged = previousSnapshot?.progress !== currentProgress;
+            const hasUpdatedAtChanged =
+              typeof currentUpdatedAt === 'string' &&
+              currentUpdatedAt !== previousSnapshot?.updatedAt;
+            const stagnantCount =
+              hasProgressChanged || hasUpdatedAtChanged
+                ? 0
+                : (previousSnapshot?.stagnantCount ?? 0) + 1;
+
+            generatingPollSnapshotsRef.current.set(linkId, {
+              progress: currentProgress,
+              updatedAt: currentUpdatedAt,
+              stagnantCount,
+            });
+
+            const attempts = generatingPollAttemptsRef.current.get(linkId) ?? 0;
+            if (
+              stagnantCount >= MAX_GENERATING_STAGNANT_POLLS ||
+              attempts >= MAX_GENERATING_POLL_ATTEMPTS
+            ) {
+              exhaustedGeneratingLinkIdsRef.current.add(linkId);
+            }
+          }
+
+          if (status === 'ready' || status === 'failed') {
+            processingLinkIdsRef.current.delete(linkId);
+            generatingPollAttemptsRef.current.delete(linkId);
+            generatingPollSnapshotsRef.current.delete(linkId);
+            exhaustedGeneratingLinkIdsRef.current.delete(linkId);
+            shouldRefetchLinks = true;
+            if (selectedLinkIdRef.current === linkId) {
+              shouldRefetchSelectedLink = true;
+            }
+          }
+        }
+
+        setSummaryStatusByLinkId(prev => {
+          let changed = false;
+          const next = { ...prev };
+
+          for (const { linkId, data, status, summaryText } of summaryUpdates) {
+            const previous = prev[linkId];
+            const merged: SummaryStatusInfo = {
+              status,
+              progress: typeof data.progress === 'number' ? data.progress : previous?.progress,
+              summary: summaryText || previous?.summary,
+              errorMessage:
+                typeof data.errorMessage === 'string' ? data.errorMessage : previous?.errorMessage,
+            };
+
+            if (
+              previous?.status === merged.status &&
+              previous?.progress === merged.progress &&
+              previous?.summary === merged.summary &&
+              previous?.errorMessage === merged.errorMessage
+            ) {
+              continue;
+            }
+
+            changed = true;
+            next[linkId] = merged;
+          }
+
+          return changed ? next : prev;
+        });
+
+        if (shouldRefetchLinks) {
+          void refetch();
+        }
+
+        if (shouldRefetchSelectedLink) {
+          void refetchSelectedLink();
+        }
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    void pollSummaryStatus();
+    const interval = window.setInterval(() => {
+      void pollSummaryStatus();
+    }, STATUS_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [isSocketConnected, refetch, refetchSelectedLink]);
 
   const handleLoadMore = useCallback(
     (_signal?: AbortSignal) => fetchNextPage().then(() => undefined),
@@ -194,7 +546,7 @@ export default function AllLink() {
     (link: Link) => {
       const statusInfo = summaryStatusByLinkId[link.id];
 
-      const summaryStatus = statusInfo?.status ?? link.summaryStatus ?? 'idle';
+      const summaryStatus = resolveLinkSummaryStatus(link, statusInfo) ?? 'idle';
       const summaryText = statusInfo?.summary ?? link.summary ?? '';
 
       return (
@@ -213,6 +565,13 @@ export default function AllLink() {
   );
 
   const hasSelection = selectedIds.size > 0;
+  const selectedStatusInfo = selectedLinkDetail
+    ? summaryStatusByLinkId[selectedLinkDetail.id]
+    : undefined;
+  const selectedSummaryText = selectedStatusInfo?.summary ?? selectedLinkDetail?.summary ?? '';
+  const selectedSummaryStatus = selectedLinkDetail
+    ? (resolveLinkSummaryStatus(selectedLinkDetail, selectedStatusInfo) ?? 'idle')
+    : 'idle';
 
   if (isLoading) {
     return (
@@ -284,9 +643,11 @@ export default function AllLink() {
                 id={selectedLinkDetail.id}
                 url={selectedLinkDetail.url}
                 title={selectedLinkDetail.title}
-                summary={selectedLinkDetail.summary ?? ''}
+                summary={selectedSummaryText}
                 memo={selectedLinkDetail.memo ?? ''}
                 imageUrl={selectedLinkDetail.imageUrl}
+                summaryState={toPanelSummaryState(selectedSummaryStatus)}
+                summaryErrorMessage={selectedStatusInfo?.errorMessage}
                 onClose={() => {
                   setIsPanelOpen(false);
                   selectLink(null);

--- a/src/app/api/links/[id]/summary-status/route.ts
+++ b/src/app/api/links/[id]/summary-status/route.ts
@@ -1,0 +1,71 @@
+import { handleApiError } from '@/hooks/util/api';
+import { serverApiClient } from '@/lib/server/apiClient';
+import { NextResponse } from 'next/server';
+
+const UPSTREAM_SUMMARY_STATUS_ENDPOINTS = [
+  (id: string) => `/v1/links/${id}/summary-status`,
+  (id: string) => `/v1/links/${id}/status`,
+  (id: string) => `/v1/links/${id}/summary/status`,
+];
+type SummaryStatusEndpointResolver = (typeof UPSTREAM_SUMMARY_STATUS_ENDPOINTS)[number];
+
+let resolvedSummaryStatusEndpoint: SummaryStatusEndpointResolver | null = null;
+
+const getErrorStatus = (error: unknown): number | null => {
+  if (!error || typeof error !== 'object' || !('status' in error)) return null;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
+};
+
+const isEndpointMissing404 = (error: unknown): boolean => getErrorStatus(error) === 404;
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const parsedId = Number(id);
+    const triedEndpoints = new Set<SummaryStatusEndpointResolver>();
+
+    if (!Number.isFinite(parsedId) || parsedId <= 0) {
+      return NextResponse.json({ success: false, message: 'Invalid id.' }, { status: 400 });
+    }
+
+    if (resolvedSummaryStatusEndpoint) {
+      triedEndpoints.add(resolvedSummaryStatusEndpoint);
+
+      try {
+        const data = await serverApiClient(resolvedSummaryStatusEndpoint(id), { method: 'GET' });
+        return NextResponse.json(data, { status: 200 });
+      } catch (error) {
+        if (!isEndpointMissing404(error)) {
+          throw error;
+        }
+
+        resolvedSummaryStatusEndpoint = null;
+      }
+    }
+
+    for (const endpointResolver of UPSTREAM_SUMMARY_STATUS_ENDPOINTS) {
+      if (triedEndpoints.has(endpointResolver)) continue;
+
+      try {
+        const data = await serverApiClient(endpointResolver(id), { method: 'GET' });
+        resolvedSummaryStatusEndpoint = endpointResolver;
+        return NextResponse.json(data, { status: 200 });
+      } catch (error) {
+        if (isEndpointMissing404(error)) {
+          triedEndpoints.add(endpointResolver);
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    return NextResponse.json(
+      { success: false, message: 'Summary status endpoint is not available.' },
+      { status: 404 }
+    );
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/components/basics/LinkCard/LinkCard.tsx
+++ b/src/components/basics/LinkCard/LinkCard.tsx
@@ -59,6 +59,7 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
       ? imageUrl
       : '';
   const safeImageUrl = getSafeUrl(normalizedImageUrl) || '/images/default_linkcard_image.png';
+  const showUnknownSummarySkeleton = summaryStatus === 'idle' && isSummaryEmpty;
 
   return (
     <div
@@ -136,6 +137,15 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
           if (summaryStatus === 'generating') {
             return (
               <div className="mt-[2.1875rem] flex flex-col gap-2">
+                <div className="bg-gray200 h-4 w-full rounded" />
+                <div className="bg-gray200 h-4 w-3/4 rounded" />
+              </div>
+            );
+          }
+
+          if (showUnknownSummarySkeleton) {
+            return (
+              <div className="flex flex-col gap-2">
                 <div className="bg-gray200 h-4 w-full rounded" />
                 <div className="bg-gray200 h-4 w-3/4 rounded" />
               </div>

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
@@ -102,7 +102,7 @@ export default function SummarySection({
       );
     }
 
-    if (summaryState === 'error' || !summary) {
+    if (summaryState === 'error') {
       return (
         <div className="flex flex-col items-center gap-2 py-6 text-center">
           <ProgressNotification
@@ -118,6 +118,19 @@ export default function SummarySection({
             label="다시 시도"
             loading={isLoading}
             onClick={onRetrySummary}
+          />
+        </div>
+      );
+    }
+
+    if (!summary) {
+      return (
+        <div className="flex min-h-[172px] flex-col gap-2 px-3 py-3">
+          <ProgressNotification
+            label={summaryState === 'ready' ? '요약 내용을 불러오는 중...' : '요약 생성 중...'}
+            icon="IC_SumGenerate"
+            tone="default"
+            animated
           />
         </div>
       );

--- a/src/types/api/linkApi.ts
+++ b/src/types/api/linkApi.ts
@@ -14,11 +14,17 @@ export interface LinkCountResponse {
 }
 export type LinkCountApiResponse = ApiResponseBase<LinkCountResponse>;
 
+export type SummaryStatusResponse = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+
 export interface LinkRes {
   id: number;
   url: string;
   title: string;
   summary?: { id: number; content: string } | string;
+  summaryStatus?: SummaryStatusResponse | Link['summaryStatus'];
+  summaryProgress?: number;
+  summaryUpdatedAt?: string;
+  summaryErrorMessage?: string;
   memo?: string;
   imageUrl?: string;
 }
@@ -73,3 +79,14 @@ export interface LinkSummaryRegenerateData {
 }
 
 export type LinkSummaryRegenerateApiResponse = ApiResponseBase<LinkSummaryRegenerateData>;
+
+export interface LinkSummaryStatusData {
+  linkId: number;
+  status: SummaryStatusResponse | Link['summaryStatus'];
+  summary?: { id: number; content: string } | string | null;
+  errorMessage?: string | null;
+  progress?: number | null;
+  updatedAt?: string | null;
+}
+
+export type LinkSummaryStatusApiResponse = ApiResponseBase<LinkSummaryStatusData>;


### PR DESCRIPTION
## 관련 이슈

- close #478

## PR 설명

- 요약 상태 조회 BFF 라우트(`/api/links/[id]/summary-status`)를 추가하고, 업스트림 엔드포인트 fallback을 적용했습니다.
- 링크 응답 정규화 시 요약 상태 미제공 케이스를 `idle`로 강제하지 않고 unknown(미확정)으로 처리하도록 변경했습니다.
- 소켓 연결 시 폴링을 중단하고, 소켓 미연결 시에만 fallback 폴링을 수행하도록 변경했습니다.
- unknown 링크는 1회 조회, generating 링크는 주기 조회로 분리했습니다.
- generating 폴링에 최대 횟수(36회)와 정체 감지(6회)를 추가해 무한 폴링을 방지했습니다.
- 폴링 에러를 재시도 가능/불가로 분리해 비재시도 에러 링크는 폴링 대상에서 제외하도록 했습니다.
- LinkCard/DetailPanel의 빈 summary 로딩 표시를 보완했습니다.
