### PR TITLE
소켓 실패 인증 처리 보완

### DIFF
--- a/src/apis/summarySocket.ts
+++ b/src/apis/summarySocket.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { clientApiClient } from '@/lib/client/apiClient';
 import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import { getAccessToken } from '@/stores/tokenStore';
 import {
@@ -19,6 +20,8 @@ if (!WS_BASE_URL) {
 
 const WS_SUMMARY_ENDPOINT = `${WS_BASE_URL}/ws/link`;
 const SUBSCRIBE_DEST = process.env.NEXT_PUBLIC_WS_SUMMARY_SUBSCRIBE_DEST ?? '/user/queue/summary';
+const envUseSockJs = process.env.NEXT_PUBLIC_WS_USE_SOCKJS;
+const DEFAULT_USE_SOCKJS = envUseSockJs === undefined ? true : envUseSockJs === 'true';
 const WS_DEBUG = process.env.NEXT_PUBLIC_WS_DEBUG === 'true';
 
 const authHeaderFromClientState = (): string | null => {
@@ -35,6 +38,30 @@ const authHeaderFromClientState = (): string | null => {
 
 const withAuthorizationHeader = (authorization: string | null): StompHeaders =>
   authorization ? { Authorization: authorization } : {};
+
+type SocketAuthResponse = {
+  success: boolean;
+  data?: {
+    authorization?: string;
+  };
+};
+
+const fetchSocketAuthorization = async (): Promise<string | null> => {
+  const clientAuthorization = authHeaderFromClientState();
+  if (clientAuthorization) return clientAuthorization;
+
+  try {
+    const response = await clientApiClient<SocketAuthResponse>('/api/socket-auth', {
+      cache: 'no-store',
+    });
+
+    if (!response.success) return null;
+    return response.data?.authorization ?? null;
+  } catch (error) {
+    logWsDebug('auth-fetch-error', error);
+    return null;
+  }
+};
 
 export type SummaryStatusPayload = {
   linkId: number;
@@ -127,7 +154,7 @@ export type SummarySocket = {
 };
 
 export const createSummarySocket = ({
-  useSockJS = true,
+  useSockJS = DEFAULT_USE_SOCKJS,
   onEvent,
   onError,
   onConnect,
@@ -198,7 +225,7 @@ export const createSummarySocket = ({
     const attempt = ++connectAttempt;
     disconnected = false;
 
-    currentAuthorization = authHeaderFromClientState();
+    currentAuthorization = await fetchSocketAuthorization();
 
     console.log('[summary-socket] connect attempt', attempt, {
       currentAuthorization: !!currentAuthorization,
@@ -222,9 +249,12 @@ export const createSummarySocket = ({
   };
 
   const disconnect = () => {
+    connectAttempt += 1;
     disconnected = true;
+    currentAuthorization = null;
     console.log('[summary-socket] disconnected');
     subscription?.unsubscribe();
+    subscription = null;
     client.deactivate();
     onDisconnect?.();
   };

--- a/src/apis/summarySocket.ts
+++ b/src/apis/summarySocket.ts
@@ -163,11 +163,18 @@ export const createSummarySocket = ({
   let currentAuthorization: string | null = null;
   let connectAttempt = 0;
   let disconnected = false;
+  let hasNotifiedDisconnect = false;
   let subscription: StompSubscription | null = null;
 
   const socketEndpoint = useSockJS
     ? toSockJsUrl(WS_SUMMARY_ENDPOINT)
     : toWebSocketUrl(WS_SUMMARY_ENDPOINT);
+
+  const notifyDisconnect = () => {
+    if (hasNotifiedDisconnect) return;
+    hasNotifiedDisconnect = true;
+    onDisconnect?.();
+  };
 
   const client = new Client({
     webSocketFactory: () => {
@@ -175,7 +182,17 @@ export const createSummarySocket = ({
       return useSockJS ? new SockJS(socketEndpoint) : new WebSocket(socketEndpoint);
     },
     connectHeaders: {},
-    beforeConnect: stompClient => {
+    beforeConnect: async stompClient => {
+      currentAuthorization = await fetchSocketAuthorization();
+
+      if (!currentAuthorization) {
+        const error = new Error('Cannot connect: authentication token is unavailable.');
+        logWsDebug('connect-auth-missing');
+        console.error('[summary-socket] auth missing');
+        onError?.(error);
+        throw error;
+      }
+
       stompClient.connectHeaders = withAuthorizationHeader(currentAuthorization);
     },
     reconnectDelay: 5000,
@@ -197,11 +214,12 @@ export const createSummarySocket = ({
     },
     onWebSocketClose: () => {
       console.warn('[summary-socket] websocket closed');
-      onDisconnect?.();
+      notifyDisconnect();
     },
   });
 
   client.onConnect = () => {
+    hasNotifiedDisconnect = false;
     console.log('[summary-socket] connected to', SUBSCRIBE_DEST);
     logWsDebug('connected', { subscribe: SUBSCRIBE_DEST });
     onConnect?.();
@@ -224,24 +242,15 @@ export const createSummarySocket = ({
   const connect = async () => {
     const attempt = ++connectAttempt;
     disconnected = false;
-
-    currentAuthorization = await fetchSocketAuthorization();
+    hasNotifiedDisconnect = false;
 
     console.log('[summary-socket] connect attempt', attempt, {
-      currentAuthorization: !!currentAuthorization,
+      useSockJS,
     });
 
     if (disconnected || attempt !== connectAttempt) {
       logWsDebug('connect-aborted', { attempt, connectAttempt, disconnected });
       console.warn('[summary-socket] connect aborted', { attempt, connectAttempt, disconnected });
-      return;
-    }
-
-    if (!currentAuthorization) {
-      const error = new Error('Cannot connect: authentication token is unavailable.');
-      logWsDebug('connect-auth-missing');
-      console.error('[summary-socket] auth missing');
-      onError?.(error);
       return;
     }
 
@@ -256,7 +265,7 @@ export const createSummarySocket = ({
     subscription?.unsubscribe();
     subscription = null;
     client.deactivate();
-    onDisconnect?.();
+    notifyDisconnect();
   };
 
   return { connect, disconnect };

--- a/src/hooks/useSummaryStatusSocket.ts
+++ b/src/hooks/useSummaryStatusSocket.ts
@@ -18,7 +18,7 @@ export const useSummaryStatusSocket = ({
   onError,
   onConnect,
   onDisconnect,
-  useSockJS = true,
+  useSockJS,
 }: UseSummaryStatusSocketOptions) => {
   const socketRef = useRef<ReturnType<typeof createSummarySocket> | null>(null);
   const onEventRef = useRef(onEvent);


### PR DESCRIPTION
## 관련 이슈

- close #501

## PR 설명
## Overview
- 배포 환경에서 `ws/link` 요약 소켓이 연결되지 않던 문제를 수정했습니다.

## Changes
- 요약 소켓에도 `/api/socket-auth` 기반 인증 fallback을 추가했습니다.
- `NEXT_PUBLIC_WS_USE_SOCKJS` 설정을 요약 소켓에도 동일하게 적용했습니다.
- 소켓 disconnect 시 내부 연결 상태와 subscription 정리를 보강했습니다.
