### PR TITLE
채팅 답변 후 자동 스크롤

### DIFF
--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -88,6 +88,7 @@ export default function Chat() {
 
   const scrollRootRef = useRef<HTMLDivElement | null>(null);
   const pendingScrollAdjustRef = useRef<{ oldHeight: number; oldTop: number } | null>(null);
+  const shouldScrollToBottomRef = useRef(false);
   const olderHistoryInFlightRef = useRef(false);
   const historyRequestSeqRef = useRef(0);
   const reactionRequestSeqRef = useRef<Record<string, number>>({});
@@ -107,77 +108,93 @@ export default function Chat() {
     }, RESPONSE_IDLE_UNLOCK_MS);
   }, [clearResponseUnlockTimer]);
 
-  const appendAiMessage = useCallback((payload: ChatSocketMessage) => {
-    setMessages(prev => {
-      const nextContent = payload.content ?? '';
-      const nextLinks = payload.links ?? null;
-
-      if (payload.messageId !== null) {
-        const sameMessageIndex = prev.findIndex(
-          message => message.role === 'ai' && message.messageId === payload.messageId
-        );
-
-        if (sameMessageIndex >= 0) {
-          return prev.map((message, index) =>
-            index === sameMessageIndex
-              ? {
-                  ...message,
-                  text: mergeAiText(message.text, nextContent),
-                  links: nextLinks ?? message.links ?? null,
-                }
-              : message
-          );
-        }
-
-        const unresolvedIndex = [...prev]
-          .reverse()
-          .findIndex(message => message.role === 'ai' && (message.messageId ?? null) === null);
-
-        if (unresolvedIndex >= 0) {
-          const targetIndex = prev.length - 1 - unresolvedIndex;
-          return prev.map((message, index) =>
-            index === targetIndex
-              ? {
-                  ...message,
-                  messageId: payload.messageId,
-                  text: mergeAiText(message.text, nextContent),
-                  links: nextLinks ?? message.links ?? null,
-                }
-              : message
-          );
-        }
-      } else {
-        const lastAiIndex = [...prev]
-          .reverse()
-          .findIndex(message => message.role === 'ai' && (message.messageId ?? null) === null);
-
-        if (lastAiIndex >= 0) {
-          const targetIndex = prev.length - 1 - lastAiIndex;
-          return prev.map((message, index) =>
-            index === targetIndex
-              ? {
-                  ...message,
-                  text: mergeAiText(message.text, nextContent),
-                  links: nextLinks ?? message.links ?? null,
-                }
-              : message
-          );
-        }
-      }
-
-      return [
-        ...prev,
-        {
-          id: `${Date.now()}-${crypto.randomUUID()}`,
-          messageId: payload.messageId,
-          role: 'ai',
-          text: nextContent,
-          links: nextLinks,
-          reaction: null,
-        },
-      ];
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    requestAnimationFrame(() => {
+      const root = scrollRootRef.current;
+      if (!root) return;
+      root.scrollTo({ top: root.scrollHeight, behavior });
     });
   }, []);
+
+  const queueScrollToBottom = useCallback(() => {
+    shouldScrollToBottomRef.current = true;
+  }, []);
+
+  const appendAiMessage = useCallback(
+    (payload: ChatSocketMessage) => {
+      queueScrollToBottom();
+      setMessages(prev => {
+        const nextContent = payload.content ?? '';
+        const nextLinks = payload.links ?? null;
+
+        if (payload.messageId !== null) {
+          const sameMessageIndex = prev.findIndex(
+            message => message.role === 'ai' && message.messageId === payload.messageId
+          );
+
+          if (sameMessageIndex >= 0) {
+            return prev.map((message, index) =>
+              index === sameMessageIndex
+                ? {
+                    ...message,
+                    text: mergeAiText(message.text, nextContent),
+                    links: nextLinks ?? message.links ?? null,
+                  }
+                : message
+            );
+          }
+
+          const unresolvedIndex = [...prev]
+            .reverse()
+            .findIndex(message => message.role === 'ai' && (message.messageId ?? null) === null);
+
+          if (unresolvedIndex >= 0) {
+            const targetIndex = prev.length - 1 - unresolvedIndex;
+            return prev.map((message, index) =>
+              index === targetIndex
+                ? {
+                    ...message,
+                    messageId: payload.messageId,
+                    text: mergeAiText(message.text, nextContent),
+                    links: nextLinks ?? message.links ?? null,
+                  }
+                : message
+            );
+          }
+        } else {
+          const lastAiIndex = [...prev]
+            .reverse()
+            .findIndex(message => message.role === 'ai' && (message.messageId ?? null) === null);
+
+          if (lastAiIndex >= 0) {
+            const targetIndex = prev.length - 1 - lastAiIndex;
+            return prev.map((message, index) =>
+              index === targetIndex
+                ? {
+                    ...message,
+                    text: mergeAiText(message.text, nextContent),
+                    links: nextLinks ?? message.links ?? null,
+                  }
+                : message
+            );
+          }
+        }
+
+        return [
+          ...prev,
+          {
+            id: `${Date.now()}-${crypto.randomUUID()}`,
+            messageId: payload.messageId,
+            role: 'ai',
+            text: nextContent,
+            links: nextLinks,
+            reaction: null,
+          },
+        ];
+      });
+    },
+    [queueScrollToBottom]
+  );
 
   const { connected, send } = useChatStream({
     chatId,
@@ -209,6 +226,7 @@ export default function Chat() {
       clearResponseUnlockTimer();
       setIsAwaitingResponse(false);
       setStreamError('답변 생성에 실패했습니다.');
+      queueScrollToBottom();
       setMessages(prev => [
         ...prev,
         {
@@ -224,6 +242,7 @@ export default function Chat() {
       if (!initialQuestion || initialSentRef.current) return;
       initialSentRef.current = true;
       setIsAwaitingResponse(true);
+      queueScrollToBottom();
       setMessages(prev => [
         ...prev,
         { id: `${Date.now()}-${crypto.randomUUID()}`, role: 'user', text: initialQuestion },
@@ -275,7 +294,7 @@ export default function Chat() {
       requestAnimationFrame(() => {
         const root = scrollRootRef.current;
         if (!root) return;
-        root.scrollTop = root.scrollHeight;
+        root.scrollTo({ top: root.scrollHeight, behavior: 'auto' });
       });
     } catch (err) {
       if (requestSeq !== historyRequestSeqRef.current) return;
@@ -331,6 +350,7 @@ export default function Chat() {
   useEffect(() => {
     historyRequestSeqRef.current += 1;
     olderHistoryInFlightRef.current = false;
+    shouldScrollToBottomRef.current = false;
     initialSentRef.current = false;
     clearResponseUnlockTimer();
     setStreamError(null);
@@ -351,16 +371,23 @@ export default function Chat() {
 
   useEffect(() => {
     const adjust = pendingScrollAdjustRef.current;
-    if (!adjust) return;
     const root = scrollRootRef.current;
     if (!root) return;
 
+    if (!adjust) {
+      if (!shouldScrollToBottomRef.current) return;
+      shouldScrollToBottomRef.current = false;
+      scrollToBottom();
+      return;
+    }
+
+    shouldScrollToBottomRef.current = false;
     requestAnimationFrame(() => {
       const newHeight = root.scrollHeight;
       root.scrollTop = newHeight - adjust.oldHeight + adjust.oldTop;
       pendingScrollAdjustRef.current = null;
     });
-  }, [messages]);
+  }, [messages, isAwaitingResponse, scrollToBottom]);
 
   const handleSubmit = (value: string) => {
     if (!connected) {
@@ -374,6 +401,7 @@ export default function Chat() {
 
     setIsAwaitingResponse(true);
     clearResponseUnlockTimer();
+    queueScrollToBottom();
     setMessages(prev => [
       ...prev,
       { id: `${Date.now()}-${crypto.randomUUID()}`, role: 'user', text: trimmedValue },


### PR DESCRIPTION
## 관련 이슈

- close #507

## PR 설명

- 채팅 화면에서 새 질문을 보내거나 AI 답변을 받을 때 채팅 영역이 자연스럽게 맨 아래로 스크롤되도록 구현했습니다.
- 답변 스트리밍 중 메시지 내용이 갱신되는 경우에도 하단 스크롤이 유지되도록 처리했습니다.
- 이전 대화 불러오기 시 기존 스크롤 위치 보정 로직과 충돌하지 않도록 자동 스크롤 로직을 분리했습니다.
- 채팅방 전환 시 남아 있는 자동 스크롤 예약 상태를 초기화했습니다.