### PR TITLE
요약 상태 복원 및 retry/re-summary UI 정합성 개선

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -121,6 +121,7 @@ const normalizeLink = (data: LinkSource): Link => {
     summaryStatus,
     summaryProgress: typeof data.summaryProgress === 'number' ? data.summaryProgress : undefined,
     summaryUpdatedAt: data.summaryUpdatedAt ?? undefined,
+    summaryErrorMessage: data.summaryErrorMessage ?? undefined,
   };
 };
 

--- a/src/apis/summary.ts
+++ b/src/apis/summary.ts
@@ -1,21 +1,22 @@
 import { clientApiClient } from '@/lib/client/apiClient';
 import type {
   RegenerateSummaryParams,
+  RetrySummaryResponse,
   SelectSummaryParams,
   SelectSummaryResponse,
   SummaryResponse,
 } from '@/types/api/summaryApi';
 
 export const retrySummary = async (id: number) => {
-  const body = await clientApiClient<SummaryResponse>(`/api/links/${id}/retry-summary`, {
+  const body = await clientApiClient<RetrySummaryResponse>(`/api/links/${id}/retry-summary`, {
     method: 'POST',
   });
 
-  if (!body?.data || !body.success) {
+  if (!body || typeof body.success !== 'boolean' || !body.success) {
     throw new Error(body?.message ?? 'Invalid response structure');
   }
 
-  return body.data;
+  return body.data ?? null;
 };
 
 export const fetchNewSummary = async (params: RegenerateSummaryParams) => {

--- a/src/apis/summarySocket.ts
+++ b/src/apis/summarySocket.ts
@@ -67,9 +67,10 @@ export type SummaryStatusPayload = {
   linkId: number;
   status: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
   progress?: number;
-  summary?: string;
+  summary?: { id?: number; content?: string } | string | null;
   errorMessage?: string;
   updatedAt?: string;
+  data?: { id?: number; content?: string } | string | null;
 };
 
 export type LinkSummaryStatus = 'idle' | 'generating' | 'ready' | 'failed';
@@ -118,6 +119,16 @@ const coerceSummaryStatus = (status: SummaryStatusPayload['status']): LinkSummar
   throw new Error(`Invalid summary status event: unsupported status "${String(status)}".`);
 };
 
+const resolveSummaryText = (
+  rawSummary: SummaryStatusPayload['summary'] | SummaryStatusPayload['data']
+): string | undefined => {
+  if (rawSummary !== null && typeof rawSummary === 'object') {
+    return typeof rawSummary.content === 'string' ? rawSummary.content : undefined;
+  }
+
+  return typeof rawSummary === 'string' ? rawSummary : undefined;
+};
+
 const parsePayload = (rawBody: string): SummaryStatusEvent => {
   const payload = JSON.parse(rawBody) as SummaryStatusPayload;
   if (typeof payload !== 'object' || payload === null) {
@@ -137,8 +148,13 @@ const parsePayload = (rawBody: string): SummaryStatusEvent => {
     linkId,
     status: coerceSummaryStatus(payload.status as SummaryStatusPayload['status']),
     progress: typeof payload.progress === 'number' ? payload.progress : undefined,
-    summary: typeof payload.summary === 'string' ? payload.summary : undefined,
-    errorMessage: typeof payload.errorMessage === 'string' ? payload.errorMessage : undefined,
+    summary: resolveSummaryText(payload.summary ?? payload.data),
+    errorMessage:
+      typeof payload.errorMessage === 'string'
+        ? payload.errorMessage
+        : payload.status === 'FAILED' && typeof payload.data === 'string'
+          ? payload.data
+          : undefined,
     updatedAt: typeof payload.updatedAt === 'string' ? payload.updatedAt : undefined,
   };
 };

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -57,16 +57,27 @@ const resolveLinkSummaryStatus = (
   statusInfo?: SummaryStatusInfo
 ): LinkSummaryStatus | undefined => {
   const summaryText = statusInfo?.summary ?? link.summary ?? '';
-  const errorMessage = statusInfo?.errorMessage;
+  const errorMessage = statusInfo?.errorMessage ?? link.summaryErrorMessage;
 
   if (statusInfo?.status) return statusInfo.status;
-  if (link.summaryStatus !== undefined) {
-    return normalizeLinkSummaryStatus(link.summaryStatus, summaryText, errorMessage);
-  }
+  if (link.summaryStatus !== undefined) return link.summaryStatus;
   if (typeof errorMessage === 'string' && errorMessage.trim()) return 'failed';
   if (hasSummaryText(summaryText)) return 'ready';
 
   return undefined;
+};
+
+const shouldHydrateMissingSummaryStatus = (link: Link, statusInfo?: SummaryStatusInfo): boolean => {
+  if (statusInfo?.status) return false;
+  if (link.summaryStatus !== undefined) return false;
+
+  const summaryText = statusInfo?.summary ?? link.summary ?? '';
+  const errorMessage = statusInfo?.errorMessage ?? link.summaryErrorMessage;
+
+  if (hasSummaryText(summaryText)) return false;
+  if (typeof errorMessage === 'string' && errorMessage.trim()) return false;
+
+  return true;
 };
 
 const toPanelSummaryState = (status: LinkSummaryStatus): 'idle' | 'loading' | 'error' | 'ready' => {
@@ -294,6 +305,149 @@ export default function AllLink() {
   });
 
   useEffect(() => {
+    let cancelled = false;
+    let inFlight = false;
+
+    const hydrateUnknownSummaryStatus = async () => {
+      if (cancelled || inFlight) return;
+
+      const linksSnapshot = linksRef.current;
+      const statusSnapshot = summaryStatusByLinkIdRef.current;
+      const targetIds: number[] = [];
+
+      for (const link of linksSnapshot) {
+        if (polledUnknownLinkIdsRef.current.has(link.id)) continue;
+        if (nonRetryablePollLinkIdsRef.current.has(link.id)) continue;
+
+        const statusInfo = statusSnapshot[link.id];
+        if (!shouldHydrateMissingSummaryStatus(link, statusInfo)) continue;
+
+        polledUnknownLinkIdsRef.current.add(link.id);
+        targetIds.push(link.id);
+      }
+
+      if (targetIds.length === 0) return;
+
+      inFlight = true;
+      try {
+        const results = await Promise.all(
+          targetIds.map(async linkId => {
+            try {
+              const data = await fetchLinkSummaryStatus(linkId);
+              return { linkId, data, retryable: false };
+            } catch (error) {
+              return {
+                linkId,
+                data: null,
+                retryable: isRetryableSummaryStatusError(error),
+              };
+            }
+          })
+        );
+
+        if (cancelled) return;
+
+        let shouldRefetchLinks = false;
+        let shouldRefetchSelectedLink = false;
+        const summaryUpdates: Array<{
+          linkId: number;
+          data: NonNullable<Awaited<ReturnType<typeof fetchLinkSummaryStatus>>>;
+          status: LinkSummaryStatus;
+          summaryText: string;
+        }> = [];
+
+        for (const result of results) {
+          if (result.data) {
+            const summaryText = resolveSummaryContent(result.data.summary);
+            const status = normalizeLinkSummaryStatus(
+              result.data.status,
+              summaryText,
+              result.data.errorMessage
+            );
+
+            nonRetryablePollLinkIdsRef.current.delete(result.linkId);
+
+            summaryUpdates.push({
+              linkId: result.linkId,
+              data: result.data,
+              summaryText,
+              status,
+            });
+            continue;
+          }
+
+          if (result.retryable) {
+            polledUnknownLinkIdsRef.current.delete(result.linkId);
+            continue;
+          }
+
+          nonRetryablePollLinkIdsRef.current.add(result.linkId);
+        }
+
+        for (const { linkId, status } of summaryUpdates) {
+          if (status === 'generating') {
+            processingLinkIdsRef.current.add(linkId);
+          }
+
+          if (status === 'ready' || status === 'failed') {
+            processingLinkIdsRef.current.delete(linkId);
+            shouldRefetchLinks = true;
+            if (selectedLinkIdRef.current === linkId) {
+              shouldRefetchSelectedLink = true;
+            }
+          }
+        }
+
+        setSummaryStatusByLinkId(prev => {
+          let changed = false;
+          const next = { ...prev };
+
+          for (const { linkId, data, status, summaryText } of summaryUpdates) {
+            const previous = prev[linkId];
+            const merged: SummaryStatusInfo = {
+              status,
+              progress: typeof data.progress === 'number' ? data.progress : previous?.progress,
+              summary: summaryText || previous?.summary,
+              errorMessage:
+                typeof data.errorMessage === 'string' ? data.errorMessage : previous?.errorMessage,
+            };
+
+            if (
+              previous?.status === merged.status &&
+              previous?.progress === merged.progress &&
+              previous?.summary === merged.summary &&
+              previous?.errorMessage === merged.errorMessage
+            ) {
+              continue;
+            }
+
+            changed = true;
+            next[linkId] = merged;
+          }
+
+          return changed ? next : prev;
+        });
+
+        if (shouldRefetchLinks) {
+          void refetch();
+        }
+
+        if (shouldRefetchSelectedLink) {
+          void refetchSelectedLink();
+        }
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    void hydrateUnknownSummaryStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [links, refetch, refetchSelectedLink]);
+
+  useEffect(() => {
     if (isSocketConnected) return;
 
     let cancelled = false;
@@ -333,7 +487,7 @@ export default function AllLink() {
           continue;
         }
 
-        if (resolvedStatus !== undefined) continue;
+        if (!shouldHydrateMissingSummaryStatus(link, statusInfo)) continue;
         if (polledUnknownLinkIdsRef.current.has(link.id)) continue;
 
         polledUnknownLinkIdsRef.current.add(link.id);
@@ -555,7 +709,7 @@ export default function AllLink() {
           isSelected={selectedIds.has(link.id)}
           summaryStatus={summaryStatus}
           summaryText={summaryText}
-          summaryErrorMessage={statusInfo?.errorMessage}
+          summaryErrorMessage={statusInfo?.errorMessage ?? link.summaryErrorMessage}
           onSelect={handleToggleSelect}
           onOpen={handleSelectLink}
         />
@@ -647,7 +801,9 @@ export default function AllLink() {
                 memo={selectedLinkDetail.memo ?? ''}
                 imageUrl={selectedLinkDetail.imageUrl}
                 summaryState={toPanelSummaryState(selectedSummaryStatus)}
-                summaryErrorMessage={selectedStatusInfo?.errorMessage}
+                summaryErrorMessage={
+                  selectedStatusInfo?.errorMessage ?? selectedLinkDetail.summaryErrorMessage
+                }
                 onClose={() => {
                   setIsPanelOpen(false);
                   selectLink(null);

--- a/src/components/basics/LinkCard/LinkCard.tsx
+++ b/src/components/basics/LinkCard/LinkCard.tsx
@@ -59,7 +59,6 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
       ? imageUrl
       : '';
   const safeImageUrl = getSafeUrl(normalizedImageUrl) || '/images/default_linkcard_image.png';
-  const showUnknownSummarySkeleton = summaryStatus === 'idle' && isSummaryEmpty;
 
   return (
     <div
@@ -137,15 +136,6 @@ const LinkCard = React.forwardRef<HTMLDivElement, LinkCardProps>(function LinkCa
           if (summaryStatus === 'generating') {
             return (
               <div className="mt-[2.1875rem] flex flex-col gap-2">
-                <div className="bg-gray200 h-4 w-full rounded" />
-                <div className="bg-gray200 h-4 w-3/4 rounded" />
-              </div>
-            );
-          }
-
-          if (showUnknownSummarySkeleton) {
-            return (
-              <div className="flex flex-col gap-2">
                 <div className="bg-gray200 h-4 w-full rounded" />
                 <div className="bg-gray200 h-4 w-3/4 rounded" />
               </div>

--- a/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
@@ -124,6 +124,18 @@ export default function SummarySection({
     }
 
     if (!summary) {
+      if (summaryState === 'idle') {
+        return (
+          <div className="flex min-h-[172px] flex-col gap-2 px-3 py-3">
+            <ProgressNotification
+              label="요약이 아직 생성되지 않았습니다."
+              icon="IC_Info"
+              tone="default"
+            />
+          </div>
+        );
+      }
+
       return (
         <div className="flex min-h-[172px] flex-col gap-2 px-3 py-3">
           <ProgressNotification
@@ -175,6 +187,10 @@ export default function SummarySection({
   };
 
   const renderActions = () => {
+    if (summaryState === 'error') {
+      return null;
+    }
+
     return (
       <div className="flex items-center justify-end gap-2 pt-2">
         <Button

--- a/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
+++ b/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
@@ -27,7 +27,7 @@ export default function ReSummaryModal({ linkId }: ReSummaryProps) {
 
   const prevContent = data?.existingSummary ?? '';
   const newContent = data?.newSummary ?? '';
-  const comparison = data?.comparison ?? '';
+  const difference = data?.difference ?? '';
 
   const handleSelectNew = () => {
     if (!data) return;
@@ -67,7 +67,7 @@ export default function ReSummaryModal({ linkId }: ReSummaryProps) {
             <div className="flex flex-col gap-2">
               <span className="relative flex items-center gap-2 rounded-lg bg-white p-2">
                 <Badge icon="IC_SumGenerate" label="어떻게 바뀌었나요?" className="h-fit" />
-                <span className="font-label-md w-full truncate">{comparison}</span>
+                <span className="font-label-md w-full truncate">{difference}</span>
               </span>
             </div>
             <div className="flex gap-2">

--- a/src/hooks/useSelectSummary.ts
+++ b/src/hooks/useSelectSummary.ts
@@ -2,8 +2,9 @@ import { selectNewSummary } from '@/apis/summary';
 import { FetchError } from '@/hooks/util/api/error/errors';
 import { useModalStore } from '@/stores/modalStore';
 import { showToast } from '@/stores/toastStore';
-import type { LinkSummaryFormat } from '@/types/api/linkApi';
-import { useMutation } from '@tanstack/react-query';
+import type { LinkListViewData, LinkSummaryFormat } from '@/types/api/linkApi';
+import type { Link } from '@/types/link';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 
 type Params = {
   id: number;
@@ -13,15 +14,51 @@ type Params = {
 
 export default function useSelectSummary() {
   const { close } = useModalStore();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (params: Params) => selectNewSummary(params),
-    onSuccess: () => {
-      close();
-      showToast({
-        message: '새로운 요약을 저장했습니다.',
-        variant: 'success',
+    onSuccess: async (data, variables) => {
+      queryClient.setQueryData<Link>(['link', variables.id], prev =>
+        prev
+          ? {
+              ...prev,
+              summary: data.content,
+              summaryStatus: 'ready',
+              summaryErrorMessage: undefined,
+              summaryProgress: undefined,
+            }
+          : prev
+      );
+
+      queryClient.setQueriesData<InfiniteData<LinkListViewData>>({ queryKey: ['links'] }, prev => {
+        if (!prev) return prev;
+
+        return {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            content: page.content.map(link =>
+              link.id === variables.id
+                ? {
+                    ...link,
+                    summary: data.content,
+                    summaryStatus: 'ready',
+                    summaryErrorMessage: undefined,
+                    summaryProgress: undefined,
+                  }
+                : link
+            ),
+          })),
+        };
       });
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['links'] }),
+        queryClient.invalidateQueries({ queryKey: ['link', variables.id] }),
+      ]);
+
+      close();
     },
     onError: err => {
       let errorMessage = '요약 저장에 실패했습니다.';

--- a/src/types/api/summaryApi.ts
+++ b/src/types/api/summaryApi.ts
@@ -17,7 +17,7 @@ export type SelectSummaryParams = {
 export type SummaryData = {
   existingSummary: string;
   newSummary: string;
-  comparison: string;
+  difference: string;
 };
 
 export type RetrySummaryResponse = {

--- a/src/types/api/summaryApi.ts
+++ b/src/types/api/summaryApi.ts
@@ -20,6 +20,14 @@ export type SummaryData = {
   comparison: string;
 };
 
+export type RetrySummaryResponse = {
+  success: boolean;
+  status: string;
+  message: string;
+  data?: SummaryData | null;
+  timestamp?: string;
+};
+
 // 요약 선택 응답 데이터
 export type SelectSummaryData = {
   id: number;

--- a/src/types/link.ts
+++ b/src/types/link.ts
@@ -4,6 +4,7 @@ export interface LinkSummaryState {
   summaryStatus?: LinkSummaryStatus;
   summaryProgress?: number;
   summaryUpdatedAt?: string;
+  summaryErrorMessage?: string;
 }
 
 export interface Link extends LinkSummaryState {


### PR DESCRIPTION
## 관련 이슈

- close #503

## PR 설명
- 요약 상태 렌더링을 `summaryStatus` 기준으로 정리했습니다.
- failed 상태 복원, retry 진입, 재생성/덮어쓰기 후 UI 반영 문제를 함께 수정했습니다.

## Changes
- 목록/상세에서 `summaryStatus`를 우선 신뢰하도록 상태 해석 정리
- 소켓 연결 중 상시 폴링 제거, 연결 끊김 시에만 fallback polling 유지
- failed 상태에서 스켈레톤 대신 실패 UI 노출
- failed 상태 패널에서는 `다시 시도`만 노출하고 `요약 재생성` 버튼 숨김
- 요약 덮어쓰기 성공 시 목록/상세 캐시 즉시 갱신
- 재생성 비교 문구 필드명을 백엔드 응답(`difference`)과 일치하도록 수정

## Notes
이 PR은 https://github.com/Team-SoFa/linkiving-core/pull/225 에 의존성이 있습니다.
해당 PR이 선행으로 해결된 이후 머지가 필요합니다.