### PR TITLE
linkapi.ts 코드래빗 경고 nitpick 해결

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -131,6 +131,7 @@ export const fetchLinks = async (
   signal?: AbortSignal
 ): Promise<LinkListViewData> => {
   const body = await clientApiClient<LinkListApiResponse>(`${LINKS_BFF}${buildQuery(params)}`, {
+    method: 'GET',
     signal,
   });
 

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -666,20 +666,12 @@ export default function AllLink() {
   }, [isSocketConnected, refetch, refetchSelectedLink]);
 
   const handleLoadMore = useCallback(
-    (signal?: AbortSignal) => {
-      if (signal) {
-        const onAbort = () => {
-          void queryClient.cancelQueries({ queryKey: ['links', 'infinite'] });
-        };
-        if (signal.aborted) {
-          onAbort();
-        } else {
-          signal.addEventListener('abort', onAbort, { once: true });
-        }
-      }
-      return fetchNextPage().then(() => undefined);
+    async (signal?: AbortSignal) => {
+      // React Query propagates its own AbortSignal via queryFn; skip only if already superseded.
+      if (signal?.aborted) return;
+      await fetchNextPage();
     },
-    [fetchNextPage, queryClient]
+    [fetchNextPage]
   );
 
   const handleSelectLink = useCallback(

--- a/src/app/api/links/[id]/summary-status/route.ts
+++ b/src/app/api/links/[id]/summary-status/route.ts
@@ -9,6 +9,7 @@ const UPSTREAM_SUMMARY_STATUS_ENDPOINTS = [
 ];
 type SummaryStatusEndpointResolver = (typeof UPSTREAM_SUMMARY_STATUS_ENDPOINTS)[number];
 
+// Best-effort memo — per runtime instance, so cold starts in serverless environments reset it.
 let resolvedSummaryStatusEndpoint: SummaryStatusEndpointResolver | null = null;
 
 const getErrorStatus = (error: unknown): number | null => {
@@ -25,15 +26,21 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
     const parsedId = Number(id);
     const triedEndpoints = new Set<SummaryStatusEndpointResolver>();
 
-    if (!Number.isFinite(parsedId) || parsedId <= 0) {
+    if (!Number.isSafeInteger(parsedId) || parsedId <= 0) {
       return NextResponse.json({ success: false, message: 'Invalid id.' }, { status: 400 });
     }
+
+    // Use the normalized numeric value for upstream requests so inputs like
+    // "01", " 123 ", "1e3", or "+5" yield consistent routing, logging, and cache keys.
+    const safeId = String(parsedId);
 
     if (resolvedSummaryStatusEndpoint) {
       triedEndpoints.add(resolvedSummaryStatusEndpoint);
 
       try {
-        const data = await serverApiClient(resolvedSummaryStatusEndpoint(id), { method: 'GET' });
+        const data = await serverApiClient(resolvedSummaryStatusEndpoint(safeId), {
+          method: 'GET',
+        });
         return NextResponse.json(data, { status: 200 });
       } catch (error) {
         if (!isEndpointMissing404(error)) {
@@ -48,7 +55,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
       if (triedEndpoints.has(endpointResolver)) continue;
 
       try {
-        const data = await serverApiClient(endpointResolver(id), { method: 'GET' });
+        const data = await serverApiClient(endpointResolver(safeId), { method: 'GET' });
         resolvedSummaryStatusEndpoint = endpointResolver;
         return NextResponse.json(data, { status: 200 });
       } catch (error) {

--- a/src/lib/client/apiClient.ts
+++ b/src/lib/client/apiClient.ts
@@ -27,7 +27,9 @@ export async function clientApiClient<T>(
         'Content-Type': 'application/json',
         ...fetchOptions.headers,
       },
-      signal,
+      signal: fetchOptions.signal
+        ? AbortSignal.any([fetchOptions.signal, controller.signal])
+        : controller.signal,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## 관련 이슈

- close #497

## PR 설명
- **linkApi**: `in` 연산자 대신 `Object.prototype.hasOwnProperty.call`로 키 검사
  (상속된 프로토타입 키 매칭 방지)
  - **summary-status route**: 검증 후 `String(parsedId)`로 정규화한 id를 업스트림
  요청에 사용 (`"01"`, `" 123 "` 등 입력에서 라우팅·로깅·캐시 키 일관성 확보)
  - **summary-status route**: 모듈 레벨 엔드포인트 캐시의 런타임 인스턴스별
  동작·한계에 대한 주석 추가
  - **AllLink**: 폴링 effect에서 `selectedLinkId`를 ref로 참조하도록 정리 (값 변경
  시 인터벌 재생성 방지)