### PR TITLE
abort signal problem

### DIFF
--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -126,8 +126,13 @@ const normalizeLink = (data: LinkSource): Link => {
 };
 
 // 전체 링크 fetch
-export const fetchLinks = async (params?: LinkListParams): Promise<LinkListViewData> => {
-  const body = await clientApiClient<LinkListApiResponse>(`${LINKS_BFF}${buildQuery(params)}`);
+export const fetchLinks = async (
+  params?: LinkListParams,
+  signal?: AbortSignal
+): Promise<LinkListViewData> => {
+  const body = await clientApiClient<LinkListApiResponse>(`${LINKS_BFF}${buildQuery(params)}`, {
+    signal,
+  });
 
   if (!body?.data || !body.success) {
     throw new Error(body?.message ?? 'Invalid response');

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -20,6 +20,7 @@ import { useLinkStore } from '@/stores/linkStore';
 import { useModalStore } from '@/stores/modalStore';
 import type { LinkSummaryStatus } from '@/types/link';
 import { type Link } from '@/types/link';
+import { useQueryClient } from '@tanstack/react-query';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 type SummaryStatusInfo = {
@@ -157,6 +158,7 @@ export default function AllLink() {
   const summaryStatusByLinkIdRef = useRef<Record<number, SummaryStatusInfo>>({});
   const selectedLinkIdRef = useRef<number | null>(selectedLinkId);
 
+  const queryClient = useQueryClient();
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useGetInfiniteLinks();
 
@@ -664,8 +666,20 @@ export default function AllLink() {
   }, [isSocketConnected, refetch, refetchSelectedLink]);
 
   const handleLoadMore = useCallback(
-    (_signal?: AbortSignal) => fetchNextPage().then(() => undefined),
-    [fetchNextPage]
+    (signal?: AbortSignal) => {
+      if (signal) {
+        const onAbort = () => {
+          void queryClient.cancelQueries({ queryKey: ['links', 'infinite'] });
+        };
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+      return fetchNextPage().then(() => undefined);
+    },
+    [fetchNextPage, queryClient]
   );
 
   const handleSelectLink = useCallback(

--- a/src/hooks/useGetInfiniteLinks.ts
+++ b/src/hooks/useGetInfiniteLinks.ts
@@ -24,12 +24,15 @@ export function useGetInfiniteLinks(
     number | null
   >({
     queryKey: ['links', 'infinite', params, size],
-    queryFn: ({ pageParam }) =>
-      fetchLinks({
-        ...params,
-        lastId: pageParam,
-        size,
-      }),
+    queryFn: ({ pageParam, signal }) =>
+      fetchLinks(
+        {
+          ...params,
+          lastId: pageParam,
+          size,
+        },
+        signal
+      ),
     initialPageParam: null,
     getNextPageParam: lastPage => {
       if (!lastPage.hasNext) return undefined;

--- a/src/lib/client/apiClient.ts
+++ b/src/lib/client/apiClient.ts
@@ -16,6 +16,10 @@ export async function clientApiClient<T>(
     controller.abort(new DOMException(`Request timed out after ${timeout}ms`, 'TimeoutError'));
   }, timeout);
 
+  const signal = fetchOptions.signal
+    ? AbortSignal.any([fetchOptions.signal, controller.signal])
+    : controller.signal;
+
   try {
     const res = await fetch(endpoint, {
       ...fetchOptions,
@@ -23,7 +27,7 @@ export async function clientApiClient<T>(
         'Content-Type': 'application/json',
         ...fetchOptions.headers,
       },
-      signal: fetchOptions.signal ?? controller.signal,
+      signal,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## 관련 이슈

- close #468

## PR 설명

### 문제
- 무한 스크롤 요청 흐름에서 `AbortSignal`이 실제 네트워크 요청까지 전달되지 않아 요청 취소가 동작하지 않음

### 변경 사항
- `AbortSignal`이 요청 끝까지 전달되도록 흐름을 연결했습니다.
- `useGetInfiniteLinks.ts` : `queryFn`에서 React Query가 관리하는 `signal`을 꺼내 `fetchLinks`로 전달 
- `linkApi.ts` : `fetchLinks(params, signal?)`로 시그니처 변경, `clientApiClient`에 signal 전달
- `apiClient.ts` : 외부 signal과 기존 타임아웃 signal을 `AbortSignal.any`로 합쳐,
  signal을 넘겨도 15초 타임아웃이 유지되도록 처리
- `AllLink.tsx` : `handleLoadMore`가 더 이상 signal을 무시하지 않고, abort 시
  `queryClient.cancelQueries`로 진행 중인 요청을 취소하도록 연결

  ### 참고

  React Query v5의 `fetchNextPage()`는 signal 인자를 받지 않고 내부적으로 자체 `AbortSignal`을 관리하므로 실제 요청 취소는 **queryFn의 signal 전달**로 이뤄지며, `InfiniteScroll`의 자체 signal은 `queryClient.cancelQueries`를 통해 React Query 취소로 연결