### PR TITLE
요약 실패시 백 문구 노출 제거

### DIFF
--- a/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
+++ b/src/components/wrappers/LinkCardDetailPanel/Sections/SummarySection.tsx
@@ -20,12 +20,7 @@ interface SummarySectionProps {
   summaryErrorMessage?: string;
 }
 
-export default function SummarySection({
-  linkId,
-  summary,
-  summaryState,
-  summaryErrorMessage,
-}: SummarySectionProps) {
+export default function SummarySection({ linkId, summary, summaryState }: SummarySectionProps) {
   const { section, summaryWrapper } = styles();
 
   const summaryRef = useRef<HTMLDivElement>(null);
@@ -106,10 +101,7 @@ export default function SummarySection({
     if (summaryState === 'error') {
       return (
         <div className="flex flex-col items-center gap-2 py-6 text-center">
-          <ProgressNotification
-            icon="IC_Info"
-            label={summaryErrorMessage || '일시적 오류로 요약을 생성하지 못했습니다.'}
-          />
+          <ProgressNotification icon="IC_Info" label="일시적 오류로 요약을 생성하지 못했습니다." />
 
           <Button
             size="sm"


### PR DESCRIPTION
## 관련 이슈

- close #536

## PR 설명

- 요약 생성 실패 시 서버에서 받은 상세 에러 대신 고정 안내 문구를 표시하도록 변경하였습니다.