### PR TITLE
Fix extend summary regeneration timeout

### DIFF
--- a/src/apis/summary.ts
+++ b/src/apis/summary.ts
@@ -24,7 +24,10 @@ export const fetchNewSummary = async (params: RegenerateSummaryParams) => {
   const format = params.format ?? 'CONCISE';
   const body = await clientApiClient<SummaryResponse>(
     `/api/links/${params.id}/summary?format=${format}`,
-    { method: 'POST' }
+    {
+      method: 'POST',
+      timeout: 30_000,
+    }
   );
 
   if (!body?.data || !body.success) {


### PR DESCRIPTION
## 관련 이슈

- close #538

## PR 설명
- 재요약 요청 API(`fetchNewSummary`)에만 타임아웃 `30_000ms`를 적용했습니다.
- 공통 API 클라이언트의 기본 타임아웃 15초는 유지해서 다른 요청 동작에는 영향을 주지 않도록 했습니다.