### PR TITLE
Use changelog for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,31 @@ jobs:
             echo "- URL: ${deployment_url}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Build release notes from changelog
+        shell: bash
+        run: |
+          awk -v tag="${TAG_NAME}" '
+            $0 == "## [" tag "]" || $0 ~ "^## \\[" tag "\\] " {
+              capture = 1
+              next
+            }
+            capture && /^## \[/ {
+              exit
+            }
+            capture {
+              print
+            }
+          ' CHANGELOG.md | sed '/^[[:space:]]*$/d' > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            {
+              echo "Could not find release notes for ${TAG_NAME} in CHANGELOG.md."
+              echo "Please add a ## [${TAG_NAME}] section before creating the tag."
+            } >&2
+            exit 1
+          fi
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: release-notes.md


### PR DESCRIPTION
## 관련 이슈

- close #547

## PR 설명

- 릴리즈 워크플로우에서 GitHub 자동 생성 릴리즈 노트 사용을 제거했습니다.
- `CHANGELOG.md`에서 현재 태그에 해당하는 섹션을 추출해 `release-notes.md`를 생성하도록 수정했습니다.
- 해당 태그의 Changelog 섹션이 없으면 릴리즈 생성 전에 명확한 에러 메시지와 함께 실패하도록 처리했습니다.
