### PR TITLE
[Analytics] GA client_id 전달 계약 추가 (#552)

### DIFF
--- a/src/apis/chatSocket.ts
+++ b/src/apis/chatSocket.ts
@@ -1,3 +1,4 @@
+import { getGaClientId } from '@/lib/client/analytics';
 import { fetchSocketAuthState, isSocketAuthFailure } from '@/lib/client/socketAuth';
 import type { EntityId } from '@/types/id';
 import {
@@ -321,7 +322,12 @@ export const createChatSocket = (options: ChatSocketOptions): ChatSocket => {
 
   const send = async (message: string) => {
     await ensureReadyToPublish();
-    const body = JSON.stringify({ chatId: String(chatId), message });
+    const clientId = await getGaClientId();
+    const body = JSON.stringify({
+      chatId: String(chatId),
+      message,
+      ...(clientId ? { clientId } : {}),
+    });
     logWsDebug('send', { destination: SEND_DEST, body });
     client.publish({
       destination: SEND_DEST,

--- a/src/apis/linkApi.ts
+++ b/src/apis/linkApi.ts
@@ -1,3 +1,4 @@
+import { withAnalyticsContext } from '@/lib/client/analytics';
 import { clientApiClient } from '@/lib/client/apiClient';
 import { ApiError } from '@/lib/errors/ApiError';
 import type {
@@ -158,9 +159,10 @@ export const fetchLinksCount = async (): Promise<number> => {
 
 // 링크 추가
 export const createLink = async (payload: CreateLinkPayload): Promise<Link> => {
+  const analyticsPayload = await withAnalyticsContext(payload);
   const body = await clientApiClient<LinkApiResponse>(LINKS_BFF, {
     method: 'POST',
-    body: JSON.stringify(payload),
+    body: JSON.stringify(analyticsPayload),
   });
 
   if (!body?.data || !body.success) {

--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AnalyticsIdentity from '@/components/AnalyticsIdentity';
 import ReactQueryProvider from '@/components/ReactQueryProvider';
 import SideNavigation from '@/components/layout/SideNavigation/SideNavigation';
 import { usePathname } from 'next/navigation';
@@ -12,6 +13,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
 
   return (
     <ReactQueryProvider>
+      {showSideNav && <AnalyticsIdentity />}
       <div className="flex min-h-screen bg-white">
         {showSideNav && <SideNavigation />}
         <main className="min-h-screen flex-1 overflow-x-clip">{children}</main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // app/layout.tsx
 import ToastContainer from '@/components/basics/Toast/ToastContainer';
+import { GA_MEASUREMENT_ID } from '@/lib/client/analytics';
 import '@/styles/globals.css';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import type { Metadata } from 'next';
@@ -61,7 +62,7 @@ export default function RootLayout({
         <LayoutClient>{children}</LayoutClient>
         <ToastContainer />
       </body>
-      <GoogleAnalytics gaId="G-Q714Z1ZKWF" />
+      <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
     </html>
   );
 }

--- a/src/components/AnalyticsIdentity.tsx
+++ b/src/components/AnalyticsIdentity.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useUserInfo } from '@/hooks/useUserInfo';
+import { setGaUserId } from '@/lib/client/analytics';
+import { useEffect } from 'react';
+
+export default function AnalyticsIdentity() {
+  const { data: user } = useUserInfo();
+
+  useEffect(() => {
+    setGaUserId(user?.id);
+  }, [user?.id]);
+
+  return null;
+}

--- a/src/hooks/server/Chats/useStompChat.ts
+++ b/src/hooks/server/Chats/useStompChat.ts
@@ -172,7 +172,8 @@ export const useStompChat = () => {
   };
 
   const sendMessage = async (chatId: string | number, content: string) => {
-    if (!clientRef.current?.connected) return;
+    const client = clientRef.current;
+    if (!client?.connected) return;
 
     addMessage({ id: `${Date.now()}`, role: 'user', content });
     addMessage({ id: `${Date.now() + 1}`, role: 'ai', content: '...' });
@@ -180,7 +181,9 @@ export const useStompChat = () => {
 
     const authorization = resolveAuthorization(tokenRef.current);
     const clientId = await getGaClientId();
-    clientRef.current.publish({
+    if (clientRef.current !== client || !client.connected) return;
+
+    client.publish({
       destination: SEND_DEST,
       body: JSON.stringify({
         chatId: String(chatId),

--- a/src/hooks/server/Chats/useStompChat.ts
+++ b/src/hooks/server/Chats/useStompChat.ts
@@ -1,4 +1,5 @@
 import { isExpiredJwt } from '@/lib/auth/jwt';
+import { getGaClientId } from '@/lib/client/analytics';
 import { COOKIES_KEYS } from '@/lib/constants/cookies';
 import { useChatStore } from '@/stores/chatStore';
 import type { EntityId } from '@/types/id';
@@ -170,7 +171,7 @@ export const useStompChat = () => {
     setGenerating(false);
   };
 
-  const sendMessage = (chatId: string | number, content: string) => {
+  const sendMessage = async (chatId: string | number, content: string) => {
     if (!clientRef.current?.connected) return;
 
     addMessage({ id: `${Date.now()}`, role: 'user', content });
@@ -178,9 +179,14 @@ export const useStompChat = () => {
     setGenerating(true);
 
     const authorization = resolveAuthorization(tokenRef.current);
+    const clientId = await getGaClientId();
     clientRef.current.publish({
       destination: SEND_DEST,
-      body: JSON.stringify({ chatId: String(chatId), message: content }),
+      body: JSON.stringify({
+        chatId: String(chatId),
+        message: content,
+        ...(clientId ? { clientId } : {}),
+      }),
       headers: toStompHeaders(authorization),
     });
   };

--- a/src/lib/client/analytics.ts
+++ b/src/lib/client/analytics.ts
@@ -2,12 +2,16 @@ export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? 'G
 
 const GA_CLIENT_ID_TIMEOUT_MS = 1000;
 
-type Gtag = (
-  command: 'config' | 'event' | 'get' | 'set',
-  targetId: string,
-  fieldOrParams?: string | Record<string, unknown>,
-  callback?: (value: string | undefined) => void
-) => void;
+type Gtag = {
+  (command: 'config' | 'event', targetId: string, params?: Record<string, unknown>): void;
+  (
+    command: 'get',
+    targetId: string,
+    fieldName: string,
+    callback: (value: string | undefined) => void
+  ): void;
+  (command: 'set', params: Record<string, unknown>): void;
+};
 
 declare global {
   interface Window {
@@ -34,29 +38,41 @@ export const getGaClientId = (timeoutMs = GA_CLIENT_ID_TIMEOUT_MS): Promise<stri
       resolve(null);
     }, timeoutMs);
 
-    gtag('get', GA_MEASUREMENT_ID, 'client_id', clientId => {
+    try {
+      gtag('get', GA_MEASUREMENT_ID, 'client_id', clientId => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeoutId);
+        resolve(typeof clientId === 'string' && clientId.trim() ? clientId : null);
+      });
+    } catch {
       if (settled) return;
       settled = true;
       window.clearTimeout(timeoutId);
-      resolve(typeof clientId === 'string' && clientId.trim() ? clientId : null);
-    });
+      resolve(null);
+    }
   });
 };
 
 export const setGaUserId = (userId: string | null | undefined) => {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
-  if (!userId) return;
 
   const gtag = window.gtag;
-  gtag('config', GA_MEASUREMENT_ID, {
-    user_id: userId,
+  gtag('set', {
+    user_id: userId ?? null,
   });
+};
+
+export const trackEvent = (name: string, params?: Record<string, unknown>) => {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+
+  window.gtag('event', name, params ?? {});
 };
 
 export const withAnalyticsContext = async <T extends object>(
   payload: T
 ): Promise<T & { clientId?: string; source: 'web' }> => {
-  const clientId = await getGaClientId();
+  const clientId = await getGaClientId().catch(() => null);
 
   return {
     ...payload,

--- a/src/lib/client/analytics.ts
+++ b/src/lib/client/analytics.ts
@@ -1,0 +1,66 @@
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? 'G-Q714Z1ZKWF';
+
+const GA_CLIENT_ID_TIMEOUT_MS = 1000;
+
+type Gtag = (
+  command: 'config' | 'event' | 'get' | 'set',
+  targetId: string,
+  fieldOrParams?: string | Record<string, unknown>,
+  callback?: (value: string | undefined) => void
+) => void;
+
+declare global {
+  interface Window {
+    gtag?: Gtag;
+  }
+}
+
+export const getGaClientId = (timeoutMs = GA_CLIENT_ID_TIMEOUT_MS): Promise<string | null> => {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise(resolve => {
+    const gtag = window.gtag;
+    if (typeof gtag !== 'function') {
+      resolve(null);
+      return;
+    }
+
+    let settled = false;
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(null);
+    }, timeoutMs);
+
+    gtag('get', GA_MEASUREMENT_ID, 'client_id', clientId => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeoutId);
+      resolve(typeof clientId === 'string' && clientId.trim() ? clientId : null);
+    });
+  });
+};
+
+export const setGaUserId = (userId: string | null | undefined) => {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  if (!userId) return;
+
+  const gtag = window.gtag;
+  gtag('config', GA_MEASUREMENT_ID, {
+    user_id: userId,
+  });
+};
+
+export const withAnalyticsContext = async <T extends object>(
+  payload: T
+): Promise<T & { clientId?: string; source: 'web' }> => {
+  const clientId = await getGaClientId();
+
+  return {
+    ...payload,
+    ...(clientId ? { clientId } : {}),
+    source: 'web',
+  };
+};


### PR DESCRIPTION
## 관련 이슈
- Closes #552

## 요약
- GA4 `client_id`를 읽는 공통 클라이언트 유틸을 추가했습니다.
- 링크 저장 요청 body에 `clientId`, `source: web`을 포함합니다.
- 채팅 WebSocket send body에도 `clientId`를 선택적으로 포함해 #272 서버 이벤트 구현과 연결될 수 있게 했습니다.
- 로그인 영역에서 GA config에 내부 `user_id`를 설정합니다.
- GA 측정 ID는 `NEXT_PUBLIC_GA_MEASUREMENT_ID` env를 우선 사용하고 기본값은 `G-Q714Z1ZKWF`로 정리했습니다.

## 테스트
- `node_modules/.bin/eslint.cmd .` 통과
- `node_modules/.bin/tsc.cmd --noEmit --tsBuildInfoFile ./.next/cache/codex-tsconfig.tsbuildinfo` 통과
- `node_modules/.bin/next.cmd build` 통과
- `pnpm lint`는 pnpm install 상태 확인 중 `approve-builds` 정책에 걸려 직접 ESLint로 대체했습니다.

