### PR TITLE
약관 동의 페이지 추가

### DIFF
--- a/src/apis/termsApi.ts
+++ b/src/apis/termsApi.ts
@@ -1,0 +1,9 @@
+import { clientApiClient } from '@/lib/client/apiClient';
+import type { TermsAgreementRequest, TermsAgreementResponse } from '@/types/api/termsApi';
+
+export const agreeTerms = async (data: TermsAgreementRequest) => {
+  return clientApiClient<TermsAgreementResponse>('/api/member/terms-agreement', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+};

--- a/src/app/(route)/terms/TermsPage.tsx
+++ b/src/app/(route)/terms/TermsPage.tsx
@@ -7,7 +7,7 @@ import Button from '@/components/basics/Button/Button';
 import Checkbox from '@/components/basics/Checkbox/Checkbox';
 import { useTermsAgreementSubmit } from '@/hooks/server/useTermsAgreement';
 import Image from 'next/image';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 const TERMS_VERSION = '2026-08-03';
 const PRIVACY_VERSION = '2026-08-03';
@@ -36,8 +36,7 @@ const TermsPage = () => {
   const [privacyAgreed, setPrivacyAgreed] = useState(false);
   const { submit, isPending } = useTermsAgreementSubmit();
 
-  const allRequiredAgreed = serviceAgreed && privacyAgreed;
-  const allAgreed = useMemo(() => serviceAgreed && privacyAgreed, [privacyAgreed, serviceAgreed]);
+  const allAgreed = serviceAgreed && privacyAgreed;
 
   const handleAllAgreementChange = (checked: boolean) => {
     setServiceAgreed(checked);
@@ -45,7 +44,7 @@ const TermsPage = () => {
   };
 
   const handleSubmit = () => {
-    if (!allRequiredAgreed || isPending) return;
+    if (!allAgreed || isPending) return;
 
     submit({
       termsAgreed: true,
@@ -158,7 +157,7 @@ const TermsPage = () => {
           size="lg"
           type="button"
           label={COPY.submit}
-          disabled={!allRequiredAgreed}
+          disabled={!allAgreed}
           loading={isPending}
           onClick={handleSubmit}
         />

--- a/src/app/(route)/terms/TermsPage.tsx
+++ b/src/app/(route)/terms/TermsPage.tsx
@@ -1,0 +1,170 @@
+﻿'use client';
+
+import IcForward from '@/components/Icons/svgs/ic_forward.svg';
+import IcLandingLogo from '@/components/Icons/svgs/ic_landing_ic_logo.svg';
+import IcLandingTextLogo from '@/components/Icons/svgs/ic_landing_text_logo.svg';
+import Button from '@/components/basics/Button/Button';
+import Checkbox from '@/components/basics/Checkbox/Checkbox';
+import { useTermsAgreementSubmit } from '@/hooks/server/useTermsAgreement';
+import Image from 'next/image';
+import { useMemo, useState } from 'react';
+
+const TERMS_VERSION = '2026-08-03';
+const PRIVACY_VERSION = '2026-08-03';
+
+const COPY = {
+  title: '\ub9c1\uce74\uc774\ube59 \uc774\uc6a9\uc57d\uad00 \ub3d9\uc758',
+  description:
+    '\ub9c1\uce74\uc774\ube59 \uc11c\ube44\uc2a4\ub97c \uc2dc\uc791\ud558\uae30 \uc704\ud574 \uc544\ub798 \uc57d\uad00 \ub3d9\uc758\uac00 \ud544\uc694\ud569\ub2c8\ub2e4',
+  allAgreement: '\uc804\uccb4 \ub3d9\uc758',
+  required: '(\ud544\uc218)',
+  serviceTerms: '\uc774\uc6a9\uc57d\uad00 \ub3d9\uc758',
+  privacyPolicy: '\uac1c\uc778\uc815\ubcf4 \ucc98\ub9ac\ubc29\uce68',
+  more: '\ub354\ubcf4\uae30',
+  submit: '\ub3d9\uc758\ud558\uace0 \uc2dc\uc791\ud558\uae30',
+};
+
+type TermKey = 'service' | 'privacy';
+
+const TERM_URLS: Record<TermKey, string> = {
+  service: 'https://linkiving.notion.site/3b1e28654151808499e4c3a8c06d727d?source=copy_link',
+  privacy: 'https://linkiving.notion.site/v1-0-3b1e2865415180dfab49ea4c733666e5?source=copy_link',
+};
+
+const TermsPage = () => {
+  const [serviceAgreed, setServiceAgreed] = useState(false);
+  const [privacyAgreed, setPrivacyAgreed] = useState(false);
+  const { submit, isPending } = useTermsAgreementSubmit();
+
+  const allRequiredAgreed = serviceAgreed && privacyAgreed;
+  const allAgreed = useMemo(() => serviceAgreed && privacyAgreed, [privacyAgreed, serviceAgreed]);
+
+  const handleAllAgreementChange = (checked: boolean) => {
+    setServiceAgreed(checked);
+    setPrivacyAgreed(checked);
+  };
+
+  const handleSubmit = () => {
+    if (!allRequiredAgreed || isPending) return;
+
+    submit({
+      termsAgreed: true,
+      privacyAgreed: true,
+      termsVersion: TERMS_VERSION,
+      privacyVersion: PRIVACY_VERSION,
+    });
+  };
+
+  const renderMoreLink = (term: TermKey) => (
+    <a
+      href={TERM_URLS[term]}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-gray500 hover:text-gray700 flex shrink-0 items-center gap-1 text-[16px] leading-[160%] font-normal tracking-[-0.02em]"
+    >
+      <span>{COPY.more}</span>
+      <IcForward className="text-gray400 size-6" aria-hidden="true" />
+    </a>
+  );
+
+  return (
+    <div className="bg-gray50 relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-10">
+      <div className="pointer-events-none absolute bottom-0 left-0 z-0 h-[34vh] min-h-56 w-full overflow-hidden">
+        <Image
+          src="/images/sofa_login_bg_resource.png"
+          alt=""
+          width={1920}
+          height={1080}
+          priority
+          className="h-full w-full object-cover object-bottom"
+        />
+      </div>
+
+      <section className="border-gray100 relative z-10 flex min-h-[570px] w-full max-w-[520px] flex-col items-center gap-20 rounded-2xl border bg-white p-8 shadow-[0_8px_30px_rgba(17,19,29,0.06)] sm:p-10">
+        <div className="flex w-full flex-col items-center gap-[60px]">
+          <div className="flex h-[26.3px] w-40 items-center justify-center gap-2.5">
+            <IcLandingLogo className="h-[26.3px] w-[30px]" aria-label="Linkiving" />
+            <IcLandingTextLogo className="h-[25.03px] w-[120px]" aria-hidden="true" />
+          </div>
+
+          <div className="flex w-full flex-col gap-10">
+            <div className="flex w-full flex-col gap-3">
+              <h1 className="text-gray900 text-[28px] leading-[160%] font-semibold">
+                {COPY.title}
+              </h1>
+              <p className="font-body-lg text-gray700">{COPY.description}</p>
+            </div>
+
+            <div className="flex w-full flex-col gap-5">
+              <div className="flex h-8 items-center justify-between">
+                <Checkbox
+                  checked={allAgreed}
+                  onChange={event => handleAllAgreementChange(event.target.checked)}
+                  label={COPY.allAgreement}
+                  labelClassName="text-[20px] leading-[160%] font-semibold"
+                  checkboxSize="lg"
+                  align="center"
+                  disabled={isPending}
+                />
+              </div>
+
+              <div className="border-gray200 w-full border-t" />
+
+              <div className="flex flex-col gap-2">
+                <div className="flex min-h-[29px] items-center justify-between gap-6">
+                  <Checkbox
+                    checked={serviceAgreed}
+                    onChange={event => setServiceAgreed(event.target.checked)}
+                    label={
+                      <span className="flex items-center gap-1">
+                        <span className="text-red500">{COPY.required}</span>
+                        <span>{COPY.serviceTerms}</span>
+                      </span>
+                    }
+                    labelClassName="text-[16px] leading-[160%] font-normal tracking-[-0.02em]"
+                    checkboxSize="lg"
+                    align="center"
+                    disabled={isPending}
+                  />
+                  {renderMoreLink('service')}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="flex min-h-[29px] items-center justify-between gap-6">
+                  <Checkbox
+                    checked={privacyAgreed}
+                    onChange={event => setPrivacyAgreed(event.target.checked)}
+                    label={
+                      <span className="flex items-center gap-1">
+                        <span className="text-red500">{COPY.required}</span>
+                        <span>{COPY.privacyPolicy}</span>
+                      </span>
+                    }
+                    labelClassName="text-[16px] leading-[160%] font-normal tracking-[-0.02em]"
+                    checkboxSize="lg"
+                    align="center"
+                    disabled={isPending}
+                  />
+                  {renderMoreLink('privacy')}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <Button
+          className="h-12 w-full"
+          size="lg"
+          type="button"
+          label={COPY.submit}
+          disabled={!allRequiredAgreed}
+          loading={isPending}
+          onClick={handleSubmit}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default TermsPage;

--- a/src/app/(route)/terms/page.tsx
+++ b/src/app/(route)/terms/page.tsx
@@ -1,0 +1,5 @@
+import TermsPage from './TermsPage';
+
+export default function Page() {
+  return <TermsPage />;
+}

--- a/src/app/api/member/terms-agreement/route.ts
+++ b/src/app/api/member/terms-agreement/route.ts
@@ -1,0 +1,81 @@
+import { handleApiError, parseJsonBody, validateRequest } from '@/hooks/util/api';
+import { createFetchError, createParseError } from '@/hooks/util/api/error/errors';
+import { extractAuthTokens, getAuthCookieOptions } from '@/lib/auth/token';
+import { COOKIES_KEYS } from '@/lib/constants/cookies';
+import type { TermsAgreementResponse } from '@/types/api/termsApi';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const BASE_API_URL = process.env.NEXT_PUBLIC_BASE_API_URL;
+if (!BASE_API_URL) {
+  throw new Error('Missing environment variable: NEXT_PUBLIC_BASE_API_URL');
+}
+
+const TermsAgreementRequestSchema = z.object({
+  termsAgreed: z.literal(true),
+  privacyAgreed: z.literal(true),
+  termsVersion: z.string().min(1),
+  privacyVersion: z.string().min(1),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await parseJsonBody(req);
+    const data = validateRequest(TermsAgreementRequestSchema, body);
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get(COOKIES_KEYS.ACCESS_TOKEN)?.value;
+    const refreshToken = cookieStore.get(COOKIES_KEYS.REFRESH_TOKEN)?.value;
+
+    const upstreamResponse = await fetch(`${BASE_API_URL}/v1/member/terms-agreement`, {
+      method: 'POST',
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: [
+          accessToken && `${COOKIES_KEYS.ACCESS_TOKEN}=${encodeURIComponent(accessToken)}`,
+          refreshToken && `${COOKIES_KEYS.REFRESH_TOKEN}=${encodeURIComponent(refreshToken)}`,
+        ]
+          .filter(Boolean)
+          .join('; '),
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!upstreamResponse.ok) {
+      const rawBody = await upstreamResponse.text().catch(() => undefined);
+      throw createFetchError(`Request failed with status ${upstreamResponse.status}`, {
+        status: upstreamResponse.status,
+        body: rawBody,
+        contentType: upstreamResponse.headers.get('content-type'),
+      });
+    }
+
+    const result = (await upstreamResponse.json().catch(() => {
+      throw createParseError('Failed to parse terms agreement response');
+    })) as TermsAgreementResponse;
+
+    const response = NextResponse.json(result, { status: 200 });
+    const tokens = extractAuthTokens({ data: result.data ?? undefined }, upstreamResponse.headers);
+
+    if (tokens?.accessToken) {
+      response.cookies.set(
+        COOKIES_KEYS.ACCESS_TOKEN,
+        tokens.accessToken,
+        getAuthCookieOptions(tokens.accessToken)
+      );
+    }
+
+    if (tokens?.refreshToken) {
+      response.cookies.set(
+        COOKIES_KEYS.REFRESH_TOKEN,
+        tokens.refreshToken,
+        getAuthCookieOptions(tokens.refreshToken)
+      );
+    }
+
+    return response;
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -8,7 +8,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
   const pathname = usePathname();
 
   // 랜딩에서는 SideNavigation 숨김
-  const showSideNav = pathname !== '/' && pathname !== '/signup';
+  const showSideNav = !['/', '/signup', '/terms'].includes(pathname);
 
   return (
     <ReactQueryProvider>

--- a/src/components/basics/Checkbox/Checkbox.tsx
+++ b/src/components/basics/Checkbox/Checkbox.tsx
@@ -34,6 +34,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
   const checkboxSizeClassName =
     checkboxSize === 'lg' ? 'size-6 rounded-[4px]' : 'size-5 rounded-md';
   const checkIconClassName = checkboxSize === 'lg' ? 'h-3 w-3.5' : 'h-2.5 w-3';
+  const errorId = error ? `${inputId}-error` : undefined;
 
   return (
     <div className={clsx('flex flex-col gap-1.5', className)}>
@@ -58,6 +59,8 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
             checked={checked}
             defaultChecked={defaultChecked}
             disabled={disabled}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={errorId}
             className="peer sr-only"
             {...rest}
           />
@@ -91,7 +94,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
         </span>
       </label>
       {error && (
-        <span role="alert" className="text-red500 pl-8 text-xs">
+        <span id={errorId} role="alert" className="text-red500 pl-8 text-xs">
           {error}
         </span>
       )}

--- a/src/components/basics/Checkbox/Checkbox.tsx
+++ b/src/components/basics/Checkbox/Checkbox.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import clsx from 'clsx';
+import React from 'react';
+
+export interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  error?: React.ReactNode;
+  align?: 'start' | 'center';
+  labelClassName?: string;
+  checkboxSize?: 'md' | 'lg';
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    id,
+    label,
+    description,
+    error,
+    align = 'start',
+    labelClassName,
+    checkboxSize = 'md',
+    className,
+    disabled,
+    checked,
+    defaultChecked,
+    ...rest
+  },
+  ref
+) {
+  const generatedId = React.useId();
+  const inputId = id ?? generatedId;
+  const checkboxSizeClassName =
+    checkboxSize === 'lg' ? 'size-6 rounded-[4px]' : 'size-5 rounded-md';
+  const checkIconClassName = checkboxSize === 'lg' ? 'h-3 w-3.5' : 'h-2.5 w-3';
+
+  return (
+    <div className={clsx('flex flex-col gap-1.5', className)}>
+      <label
+        htmlFor={inputId}
+        className={clsx(
+          'group flex cursor-pointer gap-3',
+          align === 'center' ? 'items-center' : 'items-start',
+          disabled && 'cursor-not-allowed opacity-50'
+        )}
+      >
+        <span
+          className={clsx(
+            'relative flex shrink-0 items-center justify-center',
+            checkboxSize === 'lg' ? 'mt-0 size-6' : 'mt-0.5 size-5'
+          )}
+        >
+          <input
+            ref={ref}
+            id={inputId}
+            type="checkbox"
+            checked={checked}
+            defaultChecked={defaultChecked}
+            disabled={disabled}
+            className="peer sr-only"
+            {...rest}
+          />
+          <span
+            className={clsx(
+              'border-gray300 peer-focus-visible:ring-blue200 peer-checked:border-blue500 peer-checked:bg-blue500 peer-disabled:border-gray200 peer-disabled:bg-gray100 flex items-center justify-center border bg-white transition-colors peer-focus-visible:ring-2 peer-checked:[&>svg]:block',
+              checkboxSizeClassName
+            )}
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 12 10"
+              className={clsx('hidden text-white', checkIconClassName)}
+              fill="none"
+            >
+              <path
+                d="M1 5.2 4.2 8.4 11 1"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+              />
+            </svg>
+          </span>
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col gap-1">
+          {label && (
+            <span className={clsx('font-label-md text-gray900', labelClassName)}>{label}</span>
+          )}
+          {description && <span className="font-body-sm text-gray500">{description}</span>}
+        </span>
+      </label>
+      {error && (
+        <span role="alert" className="text-red500 pl-8 text-xs">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+});
+
+Checkbox.displayName = 'Checkbox';
+
+export default Checkbox;

--- a/src/hooks/server/useTermsAgreement.ts
+++ b/src/hooks/server/useTermsAgreement.ts
@@ -1,0 +1,41 @@
+﻿'use client';
+
+import { agreeTerms } from '@/apis/termsApi';
+import { useToastStore } from '@/stores/toastStore';
+import type { TermsAgreementRequest } from '@/types/api/termsApi';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export function useTermsAgreementSubmit() {
+  const router = useRouter();
+  const { showToast } = useToastStore();
+
+  const mutation = useMutation({
+    mutationFn: (data: TermsAgreementRequest) => agreeTerms(data),
+    retry: false,
+    onSuccess: () => {
+      showToast({
+        id: 'alert',
+        message: '\uc57d\uad00 \ub3d9\uc758\uac00 \uc644\ub8cc\ub418\uc5c8\uc2b5\ub2c8\ub2e4.',
+        variant: 'success',
+        duration: 2000,
+      });
+      router.push('/home');
+      router.refresh();
+    },
+    onError: () => {
+      showToast({
+        id: 'alert',
+        message:
+          '\uc57d\uad00 \ub3d9\uc758 \ucc98\ub9ac\uc5d0 \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4. \uc7a0\uc2dc \ud6c4 \ub2e4\uc2dc \uc2dc\ub3c4\ud574 \uc8fc\uc138\uc694.',
+        variant: 'error',
+        duration: 2000,
+      });
+    },
+  });
+
+  return {
+    submit: mutation.mutate,
+    isPending: mutation.isPending,
+  };
+}

--- a/src/hooks/server/useTermsAgreement.ts
+++ b/src/hooks/server/useTermsAgreement.ts
@@ -20,8 +20,8 @@ export function useTermsAgreementSubmit() {
         variant: 'success',
         duration: 2000,
       });
-      router.push('/home');
       router.refresh();
+      router.push('/home');
     },
     onError: () => {
       showToast({

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -4,19 +4,37 @@ const decodeBase64Url = (value: string) => {
   return atob(padded);
 };
 
-export const getJwtExpMs = (token: string) => {
+export type JwtPayload = {
+  exp?: number;
+  memberStatus?: string;
+  status?: string;
+  termsAgreed?: boolean;
+};
+
+export const decodeJwtPayload = (token: string): JwtPayload | null => {
   const [, payload] = token.split('.');
   if (!payload) return null;
 
   try {
-    const decodedPayload = JSON.parse(decodeBase64Url(payload)) as { exp?: number };
-    return decodedPayload.exp ? decodedPayload.exp * 1000 : null;
+    return JSON.parse(decodeBase64Url(payload)) as JwtPayload;
   } catch {
     return null;
   }
 };
 
+export const getJwtExpMs = (token: string) => {
+  const decodedPayload = decodeJwtPayload(token);
+  return decodedPayload?.exp ? decodedPayload.exp * 1000 : null;
+};
+
 export const isExpiredJwt = (token: string) => {
   const expMs = getJwtExpMs(token);
   return expMs ? expMs <= Date.now() : true;
+};
+
+export const needsTermsAgreement = (token: string) => {
+  const payload = decodeJwtPayload(token);
+  const memberStatus = payload?.memberStatus ?? payload?.status;
+
+  return memberStatus === 'PENDING_TERMS' || payload?.termsAgreed === false;
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import { isExpiredJwt } from '@/lib/auth/jwt';
+import { isExpiredJwt, needsTermsAgreement } from '@/lib/auth/jwt';
 import {
   AuthTokenData,
   TokenResponse,
@@ -10,6 +10,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 const publicRoutes = ['/', '/signup'];
+const TERMS_ROUTE = '/terms';
 const API_BASE_URL = process.env.NEXT_PUBLIC_BASE_API_URL;
 const AUTH_REFRESH_ENDPOINT = process.env.AUTH_REFRESH_ENDPOINT ?? '/v1/auth/reissue';
 const DEV_BYPASS_LOGIN =
@@ -57,6 +58,7 @@ export async function middleware(req: NextRequest) {
   const token = req.cookies.get(COOKIES_KEYS.ACCESS_TOKEN)?.value;
   const refreshToken = req.cookies.get(COOKIES_KEYS.REFRESH_TOKEN)?.value;
   const { pathname } = req.nextUrl;
+  const isTermsRoute = pathname === TERMS_ROUTE;
 
   if (DEV_BYPASS_LOGIN) {
     if (publicRoutes.includes(pathname)) {
@@ -77,6 +79,10 @@ export async function middleware(req: NextRequest) {
         sameSite: 'lax',
       });
       return response;
+    }
+
+    if (isTermsRoute) {
+      return NextResponse.next();
     }
 
     return NextResponse.next();
@@ -100,11 +106,34 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  if (isTermsRoute) {
+    if (token && !isExpiredJwt(token)) {
+      return needsTermsAgreement(token)
+        ? NextResponse.next()
+        : NextResponse.redirect(new URL('/home', req.url));
+    }
+
+    if (refreshToken) {
+      const tokens = await reissueTokens(refreshToken);
+      if (tokens) {
+        const response = needsTermsAgreement(tokens.accessToken)
+          ? NextResponse.next()
+          : NextResponse.redirect(new URL('/home', req.url));
+        setAuthCookies(response, tokens);
+        return response;
+      }
+    }
+
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
   if (!token || isExpiredJwt(token)) {
     if (refreshToken) {
       const tokens = await reissueTokens(refreshToken);
       if (tokens) {
-        const response = NextResponse.next();
+        const response = needsTermsAgreement(tokens.accessToken)
+          ? NextResponse.redirect(new URL(TERMS_ROUTE, req.url))
+          : NextResponse.next();
         setAuthCookies(response, tokens);
         return response;
       }
@@ -113,6 +142,10 @@ export async function middleware(req: NextRequest) {
     const loginUrl = new URL('/', req.url);
     loginUrl.searchParams.set('redirect', pathname);
     return NextResponse.redirect(loginUrl);
+  }
+
+  if (needsTermsAgreement(token)) {
+    return NextResponse.redirect(new URL(TERMS_ROUTE, req.url));
   }
 
   return NextResponse.next();

--- a/src/types/api/termsApi.ts
+++ b/src/types/api/termsApi.ts
@@ -1,0 +1,13 @@
+import { ApiResponseBase } from './linkApi';
+
+export interface TermsAgreementRequest {
+  termsAgreed: true;
+  privacyAgreed: true;
+  termsVersion: string;
+  privacyVersion: string;
+}
+
+export type TermsAgreementResponse = ApiResponseBase<{
+  accessToken?: string;
+  refreshToken?: string;
+} | null>;


### PR DESCRIPTION
## 관련 이슈
- Close #557

## 요약
- 최초 회원가입 시 약관 동의를 받을 수 있는 `/terms` 페이지를 추가했습니다.
- 이용약관/개인정보 처리방침 필수 체크박스와 전체 동의 체크박스를 추가했습니다.
- 각 약관의 `더보기`는 Notion 약관 문서를 새 탭으로 열도록 연결했습니다.
- 약관 동의 제출용 클라이언트 API 훅과 Next route handler를 추가했습니다.
- 약관 동의가 필요한 사용자는 `/terms`로 이동하고, 이미 동의한 사용자는 `/terms` 접근 시 `/home`으로 이동하도록 미들웨어를 수정했습니다.

## 검증
- `tsc --noEmit --incremental false`
- `eslint src`

## 참고
- 백엔드에서 약관 동의 대기 상태를 access token payload의 `memberStatus`/`status === "PENDING_TERMS"` 또는 `termsAgreed === false`로 내려준다는 전제로 처리했습니다.

## Screenshot
<img width="2121" height="1438" alt="image" src="https://github.com/user-attachments/assets/321a04f7-f843-4f3d-a6cb-e0219c8de287" />