### PR TITLE
[Analytics] 채팅 결과/피드백 이벤트 발화 (#554)

### DIFF
--- a/src/apis/chatSocket.ts
+++ b/src/apis/chatSocket.ts
@@ -33,6 +33,7 @@ export type ChatSocketMessage = {
   success: boolean;
   chatId: EntityId;
   messageId: EntityId | null;
+  queryId: string | null;
   content: string;
   isEnd: boolean;
   step: string | string[] | null;
@@ -128,6 +129,7 @@ const parseIncomingMessage = (rawBody: string): ChatSocketMessage => {
 
   const content = typeof data.content === 'string' ? data.content : '';
   const messageId = toEntityIdOrNull(data.messageId);
+  const queryId = toEntityIdOrNull(data.queryId) ?? toEntityIdOrNull(data.query_id);
   const isEnd = typeof data.isEnd === 'boolean' ? data.isEnd : false;
   const step = toStepOrNull(data.step);
   const links = toLinksOrNull(data.links);
@@ -136,6 +138,7 @@ const parseIncomingMessage = (rawBody: string): ChatSocketMessage => {
     success: parsed.success,
     chatId,
     messageId,
+    queryId,
     content,
     isEnd,
     step,

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -10,6 +10,7 @@ import CopyButton from '@/components/wrappers/CopyButton';
 import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
 import ReportModal from '@/components/wrappers/ReportModal/ReportModal';
 import { useChatStream } from '@/hooks/server/Chats/useChatStream';
+import { trackEvent } from '@/lib/client/analytics';
 import { useModalStore } from '@/stores/modalStore';
 import { showToast } from '@/stores/toastStore';
 import type { ChatHistoryMessage } from '@/types/api/chatApi';
@@ -24,6 +25,7 @@ import ChatQueryBox from '../_components/ChatQueryBox';
 type ChatMessage = {
   id: string;
   messageId?: EntityId | null;
+  queryId?: string | null;
   role: 'user' | 'ai' | 'system';
   text: string;
   links?: ChatSocketLink[] | null;
@@ -55,6 +57,7 @@ const toReaction = (feedback?: string | null): AnswerReaction => {
 const mapHistoryMessage = (message: ChatHistoryMessage): ChatMessage => ({
   id: `history-${message.id}`,
   messageId: message.id,
+  queryId: message.queryId ?? null,
   role: message.type === 'USER' ? 'user' : 'ai',
   text: message.content,
   links: toLinks(message.links),
@@ -165,6 +168,7 @@ export default function Chat() {
       setMessages(prev => {
         const nextContent = payload.content ?? '';
         const nextLinks = payload.links ?? null;
+        const nextQueryId = payload.queryId ?? null;
 
         if (payload.messageId !== null) {
           const sameMessageIndex = prev.findIndex(
@@ -176,6 +180,7 @@ export default function Chat() {
               index === sameMessageIndex
                 ? {
                     ...message,
+                    queryId: nextQueryId ?? message.queryId ?? null,
                     text: mergeAiText(message.text, nextContent),
                     links: nextLinks ?? message.links ?? null,
                   }
@@ -194,6 +199,7 @@ export default function Chat() {
                 ? {
                     ...message,
                     messageId: payload.messageId,
+                    queryId: nextQueryId ?? message.queryId ?? null,
                     text: mergeAiText(message.text, nextContent),
                     links: nextLinks ?? message.links ?? null,
                   }
@@ -224,6 +230,7 @@ export default function Chat() {
           {
             id: `${Date.now()}-${crypto.randomUUID()}`,
             messageId: payload.messageId,
+            queryId: nextQueryId,
             role: 'ai',
             text: nextContent,
             links: nextLinks,
@@ -565,6 +572,13 @@ export default function Chat() {
         if (reactionRequestSeqRef.current[message.id] !== requestSeq) return;
 
         if (reaction === 'up') {
+          if (message.queryId) {
+            trackEvent('query_feedback', {
+              query_id: message.queryId,
+              value: 'up',
+            });
+          }
+
           showToast({
             message: '감사합니다. 제공해 주신 피드백은 Linkiving을 개선하는 데 도움이 됩니다.',
             variant: 'info',
@@ -573,6 +587,13 @@ export default function Chat() {
         }
 
         if (reaction === 'down') {
+          if (message.queryId) {
+            trackEvent('query_feedback', {
+              query_id: message.queryId,
+              value: 'down',
+            });
+          }
+
           showToast({
             message: '아쉬운 점을 알려주셔서 감사합니다. 더 나은 답변을 위해 개선하겠습니다.',
             variant: 'info',
@@ -608,6 +629,20 @@ export default function Chat() {
   const handleReport = useCallback(() => {
     openModal('REPORT');
   }, [openModal]);
+
+  const handleResultClick = useCallback(
+    (message: ChatMessage, link: ChatSocketLink, resultRank: number) => {
+      if (message.queryId) {
+        trackEvent('query_result_click', {
+          query_id: message.queryId,
+          result_rank: resultRank,
+        });
+      }
+
+      setSelectedLink(link);
+    },
+    []
+  );
 
   const latestUserMessageIndex = useMemo(
     () => messages.findLastIndex(message => message.role === 'user'),
@@ -683,14 +718,16 @@ export default function Chat() {
                               {message.links && message.links.length > 0 && (
                                 <div className="mt-4">
                                   <CardList>
-                                    {message.links.map(link => (
+                                    {message.links.map((link, linkIndex) => (
                                       <LinkCard
                                         key={link.linkId}
                                         title={link.title}
                                         link={link.url}
                                         summary={link.summary ?? ''}
                                         imageUrl={link.imageUrl ?? ''}
-                                        onClick={() => setSelectedLink(link)}
+                                        onClick={() =>
+                                          handleResultClick(message, link, linkIndex + 1)
+                                        }
                                       />
                                     ))}
                                   </CardList>
@@ -716,14 +753,16 @@ export default function Chat() {
                             <div className="pt-1">
                               {message.links && message.links.length > 0 ? (
                                 <CardList>
-                                  {message.links.map(link => (
+                                  {message.links.map((link, linkIndex) => (
                                     <LinkCard
                                       key={link.linkId}
                                       title={link.title}
                                       link={link.url}
                                       summary={link.summary ?? ''}
                                       imageUrl={link.imageUrl ?? ''}
-                                      onClick={() => setSelectedLink(link)}
+                                      onClick={() =>
+                                        handleResultClick(message, link, linkIndex + 1)
+                                      }
                                     />
                                   ))}
                                 </CardList>

--- a/src/types/api/chatApi.ts
+++ b/src/types/api/chatApi.ts
@@ -39,6 +39,7 @@ export interface ChatHistoryLink {
 export interface ChatHistoryMessage {
   id: EntityId;
   content: string;
+  queryId?: string | null;
   type: string;
   feedback?: string | null;
   time?: string | null;


### PR DESCRIPTION
## 관련이슈
- Close #554

## 작업 내용
- 채팅 소켓 응답과 채팅 히스토리 응답에서 `queryId`를 수용합니다.
- 답변 피드백 성공 시 `query_feedback` 이벤트를 발화합니다.
- 답변 결과 링크 클릭 시 `query_result_click` 이벤트를 발화합니다.

## 연동 전제
- 백엔드 `Team-SoFa/linkiving-core#272`에서 채팅 소켓/히스토리 응답에 `queryId`를 내려줘야 이벤트에 `query_id`를 포함할 수 있습니다.
- `retrieved_count`, `selected_count`, `top_similarity`는 현재 `RagAnswerRes`/n8n 응답에서 보장되지 않으므로 프론트 이벤트 파라미터에 포함하지 않았습니다.

## Stack
- Parent: `Team-SoFa/linkiving#556` / `feature/#552-ga-client-id-contract`
- Current: `Team-SoFa/linkiving#559` / `feature/#554-chat-result-feedback-events`
- Child: `Team-SoFa/linkiving#560` / `feature/#555-link-ui-events`

## 검증
- `..\..\node_modules\.bin\eslint.cmd .`
- `..\..\node_modules\.bin\tsc.cmd --noEmit --incremental false`