### PR TITLE
[Analytics] 요약 재생성/피드백 폼/링크 삭제 이벤트 발화 (#555)

### DIFF
--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -862,7 +862,7 @@ export default function AllLink() {
         <DeleteLinkModal
           links={links
             .filter(l => modal.props.linkIds.includes(l.id))
-            .map(l => ({ id: l.id, title: l.title, url: l.url }))}
+            .map(l => ({ id: l.id, title: l.title, url: l.url, createdAt: l.createdAt }))}
           onSuccess={succeededIds => {
             setSelectedIds(prev => {
               const next = new Set(prev);

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -627,6 +627,9 @@ export default function Chat() {
   }, []);
 
   const handleReport = useCallback(() => {
+    trackEvent('feedback_form_open', {
+      entry_point: 'chat_answer_more',
+    });
     openModal('REPORT');
   }, [openModal]);
 

--- a/src/components/basics/LinkCard/components/DeleteLinkModal.tsx
+++ b/src/components/basics/LinkCard/components/DeleteLinkModal.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/basics/Button/Button';
 import Modal from '@/components/basics/Modal/Modal';
 import { useDeleteLink } from '@/hooks/useDeleteLink';
 import { getSafeUrl } from '@/hooks/util/getSafeUrl';
+import { trackEvent } from '@/lib/client/analytics';
 import { useModalStore } from '@/stores/modalStore';
 import { showToast } from '@/stores/toastStore';
 import type { EntityId } from '@/types/id';
@@ -15,6 +16,7 @@ interface DeleteLinkItem {
   id: EntityId;
   title: string;
   url: string;
+  createdAt?: string;
 }
 
 interface DeleteLinkModalProps {
@@ -37,6 +39,13 @@ const DeleteLinkModal = ({ links, onSuccess }: DeleteLinkModalProps) => {
       const failed = links.filter((_, i) => results[i].status === 'rejected');
 
       if (succeeded.length > 0) {
+        succeeded.forEach(link => {
+          const daysSinceSave = getDaysSinceSave(link.createdAt);
+          trackEvent('link_delete', {
+            link_id: link.id,
+            ...(daysSinceSave === undefined ? {} : { days_since_save: daysSinceSave }),
+          });
+        });
         onSuccess?.(succeeded.map(l => l.id));
       }
 
@@ -95,6 +104,16 @@ const DeleteLinkModal = ({ links, onSuccess }: DeleteLinkModalProps) => {
       </div>
     </Modal>
   );
+};
+
+const getDaysSinceSave = (createdAt?: string): number | undefined => {
+  if (!createdAt) return undefined;
+
+  const createdTime = new Date(createdAt).getTime();
+  if (Number.isNaN(createdTime)) return undefined;
+
+  const elapsedMs = Date.now() - createdTime;
+  return Math.max(0, Math.floor(elapsedMs / 86_400_000));
 };
 
 export default DeleteLinkModal;

--- a/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
+++ b/src/components/wrappers/ReSummaryModal/ReSummaryModal.tsx
@@ -7,6 +7,7 @@ import ProgressNotification from '@/components/basics/ProgressNotification/Progr
 import useReSummary from '@/hooks/useReSummary';
 import useSelectSummary from '@/hooks/useSelectSummary';
 import MarkdownRenderer from '@/hooks/util/parseMarkdown';
+import { trackEvent } from '@/lib/client/analytics';
 import type { EntityId } from '@/types/id';
 import clsx from 'clsx';
 import { useEffect } from 'react';
@@ -22,6 +23,9 @@ export default function ReSummaryModal({ linkId }: ReSummaryProps) {
   const { mutate: selectSummary, isPending: isSaving } = useSelectSummary();
 
   useEffect(() => {
+    trackEvent('summary_regenerate', {
+      link_id: linkId,
+    });
     mutate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [linkId]);


### PR DESCRIPTION
## 관련이슈
- Close #555

## 작업 내용
- 재요약 요청 시작 시 `summary_regenerate` 이벤트를 발화합니다.
- 채팅 피드백 폼 오픈 시 `feedback_form_open` 이벤트를 발화합니다.
- 링크 삭제 성공 항목별로 `link_delete` 이벤트를 발화합니다.

## 명세 반영
- 저장 콘텐츠 표현은 `bookmark` 대신 `link` 기준으로 정리했습니다.
- 삭제 이벤트는 `link_id`를 사용하고, 저장 시점이 있는 경우 `days_since_save`를 함께 보냅니다.

## Stack
- Parent: `Team-SoFa/linkiving#559` / `feature/#554-chat-result-feedback-events`
- Current: `Team-SoFa/linkiving#560` / `feature/#555-link-ui-events`

## 검증
- `..\..\node_modules\.bin\eslint.cmd .`
- `..\..\node_modules\.bin\tsc.cmd --noEmit --incremental false`