### PR TITLE
[Analytics] 신규 가입 sign_up 이벤트 발화 (#553)

### DIFF
--- a/src/hooks/server/useTermsAgreement.ts
+++ b/src/hooks/server/useTermsAgreement.ts
@@ -1,19 +1,34 @@
 ﻿'use client';
 
+import { fetchUserInfo } from '@/apis/authApi';
 import { agreeTerms } from '@/apis/termsApi';
+import { trackGoogleSignUp } from '@/lib/client/signUpAnalytics';
 import { useToastStore } from '@/stores/toastStore';
 import type { TermsAgreementRequest } from '@/types/api/termsApi';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 export function useTermsAgreementSubmit() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { showToast } = useToastStore();
 
   const mutation = useMutation({
     mutationFn: (data: TermsAgreementRequest) => agreeTerms(data),
     retry: false,
-    onSuccess: () => {
+    onSuccess: async () => {
+      let gaUserId: string | null = null;
+
+      try {
+        const user = await fetchUserInfo();
+        queryClient.setQueryData(['userInfo'], user);
+        gaUserId = user.id;
+      } catch {
+        void queryClient.invalidateQueries({ queryKey: ['userInfo'] });
+      }
+
+      trackGoogleSignUp(gaUserId);
+
       showToast({
         id: 'alert',
         message: '\uc57d\uad00 \ub3d9\uc758\uac00 \uc644\ub8cc\ub418\uc5c8\uc2b5\ub2c8\ub2e4.',

--- a/src/hooks/server/useTermsAgreement.ts
+++ b/src/hooks/server/useTermsAgreement.ts
@@ -4,7 +4,7 @@ import { fetchUserInfo } from '@/apis/authApi';
 import { agreeTerms } from '@/apis/termsApi';
 import { trackGoogleSignUp } from '@/lib/client/signUpAnalytics';
 import { useToastStore } from '@/stores/toastStore';
-import type { TermsAgreementRequest } from '@/types/api/termsApi';
+import type { TermsAgreementRequest, TermsAgreementResponse } from '@/types/api/termsApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
@@ -16,8 +16,9 @@ export function useTermsAgreementSubmit() {
   const mutation = useMutation({
     mutationFn: (data: TermsAgreementRequest) => agreeTerms(data),
     retry: false,
-    onSuccess: async () => {
+    onSuccess: async response => {
       let gaUserId: string | null = null;
+      const shouldTrackSignUp = hasIssuedTermsCompletionToken(response);
 
       try {
         const user = await fetchUserInfo();
@@ -27,7 +28,9 @@ export function useTermsAgreementSubmit() {
         void queryClient.invalidateQueries({ queryKey: ['userInfo'] });
       }
 
-      trackGoogleSignUp(gaUserId);
+      if (shouldTrackSignUp) {
+        trackGoogleSignUp(gaUserId);
+      }
 
       showToast({
         id: 'alert',
@@ -54,3 +57,7 @@ export function useTermsAgreementSubmit() {
     isPending: mutation.isPending,
   };
 }
+
+const hasIssuedTermsCompletionToken = (response: TermsAgreementResponse) => {
+  return Boolean(response.data?.accessToken || response.data?.refreshToken);
+};

--- a/src/lib/client/signUpAnalytics.ts
+++ b/src/lib/client/signUpAnalytics.ts
@@ -5,6 +5,8 @@ type Gtag = {
   (command: 'event', eventName: string, params?: Record<string, unknown>): void;
 };
 
+type GtagCommand = ['set', Record<string, unknown>] | ['event', string, Record<string, unknown>];
+
 const getGtag = (): Gtag | null => {
   if (typeof window === 'undefined') return null;
 
@@ -13,11 +15,22 @@ const getGtag = (): Gtag | null => {
 };
 
 export const trackGoogleSignUp = (userId?: string | null) => {
-  const gtag = getGtag();
-  if (!gtag) return;
+  const analyticsUserId = userId?.trim();
+  if (!analyticsUserId) return;
 
-  if (userId) {
-    gtag('set', { user_id: userId });
+  const setUserIdCommand: GtagCommand = ['set', { user_id: analyticsUserId }];
+  const signUpCommand: GtagCommand = ['event', 'sign_up', { method: 'google' }];
+  const gtag = getGtag();
+
+  if (!gtag) {
+    if (typeof window !== 'undefined') {
+      const analyticsWindow = window as { dataLayer?: GtagCommand[] };
+      analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
+      analyticsWindow.dataLayer.push(setUserIdCommand, signUpCommand);
+    }
+    return;
   }
+
+  gtag('set', { user_id: analyticsUserId });
   gtag('event', 'sign_up', { method: 'google' });
 };

--- a/src/lib/client/signUpAnalytics.ts
+++ b/src/lib/client/signUpAnalytics.ts
@@ -1,0 +1,23 @@
+'use client';
+
+type Gtag = {
+  (command: 'set', params: Record<string, unknown>): void;
+  (command: 'event', eventName: string, params?: Record<string, unknown>): void;
+};
+
+const getGtag = (): Gtag | null => {
+  if (typeof window === 'undefined') return null;
+
+  const gtag = (window as { gtag?: unknown }).gtag;
+  return typeof gtag === 'function' ? (gtag as Gtag) : null;
+};
+
+export const trackGoogleSignUp = (userId?: string | null) => {
+  const gtag = getGtag();
+  if (!gtag) return;
+
+  if (userId) {
+    gtag('set', { user_id: userId });
+  }
+  gtag('event', 'sign_up', { method: 'google' });
+};


### PR DESCRIPTION
## 관련이슈
- Closes #553

## 요약
- 약관 동의 완료 성공 경로에서만 GA4 sign_up 이벤트를 발화합니다.
- sign_up 발화 전에 /api/member/me로 내부 사용자 ID를 조회해 GA user_id를 설정합니다.
- 이메일/구글 계정 ID 등 원문 식별자는 이벤트 payload에 포함하지 않습니다.
- 사용자 정보 조회 성공 시 React Query userInfo 캐시를 갱신합니다.

## 검증
- npx eslint src
- npx tsc --noEmit --incremental false

## 참고
- 이 PR은 #558(feature/#557-terms-agreement-page) 위에 쌓은 stacked PR입니다.
- sign_up은 약관 동의 완료 시점에만 발화하므로 기존 회원 재로그인/재방문에서는 발화되지 않습니다.