### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v0.1.1] - 26.08.05
+
 ### Added
 
 - 프로필 메뉴를 통해 개인정보 처리방침, 이용 약관, 오류 문의 등을 확인하고 문의할 수 있도록 추가했습니다.
@@ -21,4 +23,5 @@
 - 채팅 목록을 확인하고 이전 대화를 다시 열 수 있습니다.
 - 회원가입 후 개인 보관함처럼 서비스를 사용할 수 있습니다.
 
+[v0.1.1]: https://github.com/Team-SoFa/linkiving/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/Team-SoFa/linkiving/compare/0.1.0...main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sofa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@10.19.0",
   "type": "module",


### PR DESCRIPTION
## 관련 이슈

- close #564

## PR 설명

v0.1.1 릴리즈 준비 PR입니다.

- `package.json` 버전을 `0.1.1`로 갱신
- `CHANGELOG.md`에 `v0.1.1 - 26.08.05` 릴리즈 섹션 추가
- v0.1.1 비교 링크 추가

## 검증

- `prettier --check CHANGELOG.md package.json`
- `eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0`
- `tsc --noEmit`
- `next build`