### PR TITLE
사이드네비게이션 모바일 디자인 수정

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/nextjs';
 
 import '../src/styles/globals.css';
+import { withQueryClient } from './withQueryClient';
 
 // Storybook 환경에서만 fallback 주입
 if (!process.env.NEXT_PUBLIC_BASE_API_URL) {
@@ -12,6 +13,9 @@ if (!process.env.NEXT_PUBLIC_API_TOKEN) {
 }
 
 const preview: Preview = {
+  // react-query 를 쓰는 컴포넌트(ChatRoomSection, SideNavigationBottom 등)가
+  // "No QueryClient set" 으로 죽지 않도록 전역 Provider 를 씌운다.
+  decorators: [withQueryClient],
   parameters: {
     nextjs: {
       appDirectory: true, // App Router 사용 시 필수

--- a/.storybook/withQueryClient.tsx
+++ b/.storybook/withQueryClient.tsx
@@ -1,0 +1,24 @@
+import type { Decorator } from '@storybook/nextjs';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+/**
+ * react-query 를 쓰는 컴포넌트가 Storybook 에서 "No QueryClient set" 으로
+ * 죽지 않도록 전역으로 씌우는 Provider.
+ *
+ * 스토리별로 데이터를 시드하고 싶으면 스토리 데코레이터에서 자체 QueryClient 로
+ * 한 번 더 감싸면 된다 (가까운 Provider 가 이긴다).
+ */
+export const withQueryClient: Decorator = Story => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+
+  return (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  );
+};
+
+export default withQueryClient;

--- a/src/app/(dev)/mock-chat/MockChatPage.tsx
+++ b/src/app/(dev)/mock-chat/MockChatPage.tsx
@@ -143,9 +143,11 @@ export default function MockChatPage() {
   };
 
   return (
-    <div className="h-screen w-full xl:flex">
-      <div className="custom-scrollbar min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1">
-        <div className="mx-auto flex h-screen w-full max-w-[816px] flex-col px-4 pt-6">
+    <div className="h-full w-full xl:flex">
+      {/* 부모가 xl 부터만 flex 라 모바일에서는 flex-1 이 무효 → h-full 로 직접 높이를 준다 */}
+      <div className="custom-scrollbar h-full min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pr-1">
+        {/* QueryBox 가 스크롤 흐름 안에 있으므로 h-full 이 아니라 min-h-full (내용이 길면 늘어나야 함) */}
+        <div className="mx-auto flex min-h-full w-full max-w-[816px] flex-col px-4 pt-6">
           <div className="flex min-h-0 flex-1 flex-col gap-3 pb-42">
             {messages.map((message, index) => (
               <div
@@ -244,7 +246,7 @@ export default function MockChatPage() {
       </div>
 
       {selectedLink && (
-        <aside className="border-gray200 hidden h-screen shrink-0 border-l xl:block xl:w-130">
+        <aside className="border-gray200 hidden h-full shrink-0 border-l xl:block xl:w-130">
           <LinkCardDetailPanel
             id={selectedLink.linkId}
             url={selectedLink.url}

--- a/src/app/(route)/all-link/AllLink.tsx
+++ b/src/app/(route)/all-link/AllLink.tsx
@@ -768,7 +768,7 @@ export default function AllLink() {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen w-full items-center justify-center">
+      <div className="flex h-full w-full items-center justify-center">
         <Spinner size={36} />
       </div>
     );
@@ -776,7 +776,7 @@ export default function AllLink() {
 
   if (isError && !data) {
     return (
-      <div className="flex min-h-screen w-full flex-col items-center justify-center gap-2">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2">
         <p className="text-gray600">링크를 불러오지 못했습니다.</p>
         <Button onClick={() => refetch()} label="다시 시도" />
       </div>
@@ -784,8 +784,8 @@ export default function AllLink() {
   }
 
   return (
-    <div className="h-screen min-w-0">
-      <div className="flex h-screen min-w-0 flex-col xl:flex-row">
+    <div className="h-full min-w-0">
+      <div className="flex h-full min-w-0 flex-col xl:flex-row">
         <div className="min-w-0 flex-1 px-10 py-15" onWheel={handleLeftPaneWheel}>
           <div className="mx-auto flex h-full w-full max-w-200 flex-col gap-5">
             <header className="flex items-center justify-between">
@@ -808,7 +808,7 @@ export default function AllLink() {
               ) : (
                 <InfiniteScroll
                   ref={listRef}
-                  className="custom-scrollbar h-full overflow-y-auto p-1"
+                  className="custom-scrollbar h-full overflow-y-auto overscroll-contain p-1"
                   items={links}
                   getKey={item => item.id}
                   renderItem={renderItem}
@@ -822,7 +822,7 @@ export default function AllLink() {
         </div>
 
         {isPanelOpen && (
-          <aside className="xl:h-screen xl:w-130 xl:shrink-0">
+          <aside className="xl:h-full xl:w-130 xl:shrink-0">
             {isSelectedLinkLoading ? (
               <div className="border-gray200 flex h-full items-center justify-center rounded-2xl border bg-white p-6">
                 <Spinner />

--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -660,12 +660,12 @@ export default function Chat() {
   }, [latestUserMessageIndex, messages]);
 
   return (
-    <div className="h-screen w-full xl:flex">
+    <div className="h-full w-full xl:flex">
       <div className="relative h-full min-w-0 flex-1">
         <div
           ref={scrollRootRef}
           onScroll={handleScroll}
-          className="custom-scrollbar h-full overflow-x-hidden overflow-y-auto pr-1"
+          className="custom-scrollbar h-full overflow-x-hidden overflow-y-auto overscroll-contain pr-1"
         >
           <div className="mx-auto flex min-h-full w-full max-w-[816px] flex-col px-4 pt-15">
             {streamError && (
@@ -809,7 +809,7 @@ export default function Chat() {
       </div>
 
       {selectedLink && (
-        <aside className="xl:border-gray200 xl:h-screen xl:w-130 xl:shrink-0 xl:border-l">
+        <aside className="xl:border-gray200 xl:h-full xl:w-130 xl:shrink-0 xl:border-l">
           <LinkCardDetailPanel
             id={selectedLink.linkId}
             url={selectedLink.url}

--- a/src/app/(route)/home/HomePage.tsx
+++ b/src/app/(route)/home/HomePage.tsx
@@ -19,7 +19,7 @@ export default function Home() {
   // 로딩중 화면
   if (creating || redirecting) {
     return (
-      <div className="relative flex h-screen w-full justify-center">
+      <div className="relative flex h-full w-full justify-center">
         <div className="relative flex h-full w-full max-w-[816px] flex-1 flex-col px-4">
           <div className="absolute top-15 right-4 max-w-[70%]">
             <span className="bg-blue50 block rounded-2xl px-4 py-3 whitespace-pre-wrap">
@@ -51,7 +51,7 @@ export default function Home() {
   }
 
   return (
-    <div className="flex h-screen w-full flex-col items-center justify-center">
+    <div className="flex h-full w-full flex-col items-center justify-center">
       <div className="mb-7 ml-4 flex w-full max-w-184 flex-col">
         <div className="font-title-md ml-6 flex flex-col gap-1.5 md:flex-row">
           <span>저장한 링크 속 내용을 바탕으로</span>

--- a/src/app/(route)/home/loading.tsx
+++ b/src/app/(route)/home/loading.tsx
@@ -2,7 +2,7 @@ import Spinner from '@/components/basics/Spinner/Spinner';
 
 export default function Loading() {
   return (
-    <div className="flex h-screen w-screen items-center justify-center">
+    <div className="flex h-full w-full items-center justify-center">
       <Spinner />
     </div>
   );

--- a/src/app/(route)/mypage/Mypage.tsx
+++ b/src/app/(route)/mypage/Mypage.tsx
@@ -25,7 +25,7 @@ export default function Mypage() {
   // if (!user) return null;
 
   return (
-    <div className="relative flex h-screen w-full flex-col items-center justify-center">
+    <div className="relative flex h-full w-full flex-col items-center justify-center">
       <span>마이페이지</span>
       <Button
         label={isLoggingOut ? '로그아웃 중...' : '로그아웃'}

--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -3,21 +3,43 @@
 import AnalyticsIdentity from '@/components/AnalyticsIdentity';
 import ReactQueryProvider from '@/components/ReactQueryProvider';
 import SideNavigation from '@/components/layout/SideNavigation/SideNavigation';
+import SideNavModals from '@/components/layout/SideNavigation/components/SideNavModals';
+import { useIsMobile } from '@/hooks/util/useIsMobile';
+import { useSideNavStore } from '@/stores/sideNavStore';
+import clsx from 'clsx';
 import { usePathname } from 'next/navigation';
 
 export default function LayoutClient({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const isMobile = useIsMobile();
+  const isSideNavOpen = useSideNavStore(state => state.isOpen);
 
   // 랜딩에서는 SideNavigation 숨김
   const showSideNav = !['/', '/signup', '/terms'].includes(pathname);
+  const isDrawerOpen = showSideNav && isMobile && isSideNavOpen;
 
   return (
     <ReactQueryProvider>
       {showSideNav && <AnalyticsIdentity />}
-      <div className="flex min-h-screen bg-white">
+      {/*
+        사이드내비 라우트는 셸을 정확히 한 뷰포트로 고정한다.
+        - 문서가 스크롤되지 않으므로 모바일 URL 바가 접히지 않고,
+          그에 따른 position:fixed 히트테스트 어긋남(모바일 열림 버튼 미작동)이 원천 차단된다.
+        - 드로어를 열었을 때 배경 스크롤도 자동으로 막힌다 (별도 body lock 불필요).
+        해당 라우트들은 모두 내부 스크롤 컨테이너를 갖고 있어 잃는 것이 없다.
+        랜딩/가입/약관은 기존대로 창 스크롤을 유지한다.
+      */}
+      <div className={clsx('flex bg-white', showSideNav ? 'h-dvh overflow-hidden' : 'min-h-dvh')}>
         {showSideNav && <SideNavigation />}
-        <main className="min-h-screen flex-1 overflow-x-clip">{children}</main>
+        <main
+          inert={isDrawerOpen}
+          className={clsx('min-w-0 flex-1 overflow-x-clip', showSideNav ? 'h-full' : 'min-h-dvh')}
+        >
+          {children}
+        </main>
       </div>
+      {/* 드로어가 닫힐 때 함께 언마운트되지 않도록 셸 밖에서 렌더한다 */}
+      {showSideNav && <SideNavModals />}
     </ReactQueryProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import ToastContainer from '@/components/basics/Toast/ToastContainer';
 import { GA_MEASUREMENT_ID } from '@/lib/client/analytics';
 import '@/styles/globals.css';
 import { GoogleAnalytics } from '@next/third-parties/google';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 
 import LayoutClient from './layout-client';
 
@@ -49,7 +49,12 @@ export const metadata: Metadata = {
   },
 };
 
-export const viewport = 'width=device-width, initial-scale=1, maximum-scale=1';
+// App Router 는 문자열이 아닌 Viewport 객체를 기대한다.
+// maximum-scale 은 의도적으로 지정하지 않는다 (확대 차단은 WCAG 1.4.4 위반).
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 
 export default function RootLayout({
   children,

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex h-screen w-screen items-center justify-center">
+    <div className="flex h-full min-h-dvh w-full items-center justify-center">
       <div className="relative h-14 w-16">
         {/* Ring A: 왼쪽 아래 고리 */}
         <svg

--- a/src/components/basics/Button/Button.tsx
+++ b/src/components/basics/Button/Button.tsx
@@ -59,7 +59,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : 'button'; // 인터랙션 요소 중첩 방지를 위해 Slot 적용
 
     return (
+      // rest 를 먼저 펼쳐 disabled / type / aria-* 가 덮이지 않게 한다
       <Comp
+        {...rest}
         ref={ref}
         className={clsx(classes, className)}
         disabled={isDisabled}
@@ -67,7 +69,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         aria-disabled={isDisabled}
         aria-busy={loading || undefined}
         onClick={isDisabled ? undefined : onClick}
-        {...rest}
       >
         {loading ? (
           <div className="flex h-full w-full items-center justify-center">

--- a/src/components/basics/IconButton/IconButton.tsx
+++ b/src/components/basics/IconButton/IconButton.tsx
@@ -49,14 +49,15 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     const Comp = asChild ? Slot : 'button';
 
     return (
+      // rest 를 먼저 펼쳐 aria-label / onClick / type 이 덮이지 않게 한다
       <Comp
+        {...rest}
         ref={ref}
         className={clsx(classes, className)}
         disabled={disabled}
         type={type}
         aria-label={ariaLabel}
         onClick={onClick}
-        {...rest}
       >
         {asChild ? (
           children

--- a/src/components/basics/Modal/Modal.style.ts
+++ b/src/components/basics/Modal/Modal.style.ts
@@ -6,7 +6,8 @@ export const modalOverlayStyle = tv({
 });
 
 export const modalContentStyle = tv({
-  base: 'bg-gray50 max-md:modal-slide-up relative h-auto w-auto rounded-2xl shadow-lg max-md:m-0! max-md:w-full! max-md:max-w-none! max-md:min-w-0! max-md:rounded-b-none!',
+  // 짧은 모바일 화면에서 긴 본문이 잘리지 않도록 최대 높이 + 자체 스크롤
+  base: 'bg-gray50 custom-scrollbar max-md:modal-slide-up relative h-auto max-h-[85dvh] w-auto overflow-y-auto overscroll-contain rounded-2xl shadow-lg max-md:m-0! max-md:w-full! max-md:max-w-none! max-md:min-w-0! max-md:rounded-b-none!',
 });
 
 export const modalHeaderStyle = tv({

--- a/src/components/basics/Popover/Content.tsx
+++ b/src/components/basics/Popover/Content.tsx
@@ -26,7 +26,8 @@ const PopoverContent = ({ children, popoverKey, className }: PopoverContentProps
     anchorRef.current = anchorEl ?? null;
   }, [anchorEl]);
 
-  const { refs, floatingStyles } = usePopoverPosition(anchorRef.current, isActive, placement);
+  // 위치 갱신은 usePopoverPosition 내부의 autoUpdate 가 담당한다 (스크롤/리사이즈 추적)
+  const { refs, floatingStyles } = usePopoverPosition(anchorRef.current, placement);
 
   useOutsideClick([contentRef, anchorRef], close, isActive);
 

--- a/src/components/basics/Popover/Trigger.tsx
+++ b/src/components/basics/Popover/Trigger.tsx
@@ -22,6 +22,14 @@ interface PopoverTriggerProps {
   popoverKey: string;
   label?: string;
 }
+
+/**
+ * Button/IconButton 은 접근성 이름을 `aria-label` 이 아니라 자체 prop 인 `ariaLabel` 로 받는다.
+ * 여기서 `aria-label: undefined` 를 무조건 주입하면, 두 컴포넌트가 `{...rest}` 를
+ * `aria-label={ariaLabel}` 뒤에 펼치기 때문에 이름이 지워진다.
+ */
+type LabelledChildProps = { ariaLabel?: string; 'aria-label'?: string };
+
 const PopoverTrigger = ({ children, popoverKey, label }: PopoverTriggerProps) => {
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const { activeKey, toggle, close } = usePopover();
@@ -36,6 +44,9 @@ const PopoverTrigger = ({ children, popoverKey, label }: PopoverTriggerProps) =>
     }
   };
 
+  const childProps = children.props as LabelledChildProps;
+  const resolvedLabel = label ?? childProps.ariaLabel ?? childProps['aria-label'];
+
   return cloneElement(children, {
     ref: useMergedRefs(triggerRef, children.props.ref),
     onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -44,7 +55,8 @@ const PopoverTrigger = ({ children, popoverKey, label }: PopoverTriggerProps) =>
     },
     'aria-haspopup': true,
     'aria-expanded': isActive,
-    'aria-label': label || children.props['aria-label'],
+    // 값이 있을 때만 넘긴다. undefined 를 명시적으로 넘기면 자식이 이미 설정한 값을 덮어쓴다.
+    ...(resolvedLabel ? { 'aria-label': resolvedLabel } : {}),
   } as Partial<ButtonLikeProps>);
 };
 export default PopoverTrigger;

--- a/src/components/basics/Popover/hooks/usePopoverPosition.ts
+++ b/src/components/basics/Popover/hooks/usePopoverPosition.ts
@@ -1,27 +1,25 @@
 'use client';
 
-import { Placement, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
+import { Placement, autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { useEffect } from 'react';
 
 export const usePopoverPosition = (
   triggerRef: HTMLElement | null, // 기준이 되는 엘리먼트 (trigger)
-  isOpen: boolean, // Popover가 열려있을 때만 위치를 계산
   placement: Placement = 'bottom-start' // 기본 위치
 ) => {
-  const { refs, floatingStyles, update } = useFloating({
+  const { refs, floatingStyles } = useFloating({
     placement,
-    middleware: [offset(6), flip(), shift()], // 기준 요소로부터의 거리, 화면 공간에 맞춰 뒤집기, 화면 안으로 밀어넣기
+    // 기준 요소로부터의 거리, 화면 공간에 맞춰 뒤집기, 화면 안으로 밀어넣기(가장자리 8px 여백)
+    middleware: [offset(6), flip(), shift({ padding: 8 })],
+    // 스크롤 가능한 조상/리사이즈를 구독해 위치를 계속 갱신한다.
+    // 사이드 내비게이션처럼 스크롤되는 컨테이너 안의 트리거에서 필수.
+    whileElementsMounted: autoUpdate,
   });
 
   // trigger를 Floating UI에 연결
   useEffect(() => {
     refs.setReference(triggerRef);
   }, [triggerRef, refs]);
-
-  // Popover가 열릴 때마다 위치 업데이트
-  useEffect(() => {
-    if (isOpen) update();
-  }, [isOpen, update]);
 
   return { refs, floatingStyles };
 };

--- a/src/components/layout/SideNavigation/SideNavigation.tsx
+++ b/src/components/layout/SideNavigation/SideNavigation.tsx
@@ -1,61 +1,68 @@
 'use client';
 
+import useEscKeyPress from '@/hooks/util/useEscKeyPress';
+import { useIsMobile } from '@/hooks/util/useIsMobile';
 import { useSideNavStore } from '@/stores/sideNavStore';
 import { AnimatePresence, motion } from 'framer-motion';
 import { usePathname } from 'next/navigation';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import SideNavigationBottom from './components/Bottom/SideNavigationBottom';
 import ChatRoomSection from './components/ChatRoomSection/ChatRoomSection';
 import SideNavigationHeader from './components/Header/SideNavigationHeader';
 import MenuSection from './components/MenuSection/MenuSection';
 
-function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useLayoutEffect(() => {
-    const mq = window.matchMedia('(max-width: 767px)');
-    setIsMobile(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-
-  return isMobile;
-}
+/** 메뉴 + 채팅 목록을 담는 단일 스크롤 영역. 중첩 스크롤러는 iOS 에서 터치가 갇히므로 만들지 않는다. */
+const SCROLLER_CLASS =
+  'custom-scrollbar flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-contain';
 
 export default function SideNavigation() {
-  const { isOpen, toggle, setOpen } = useSideNavStore();
+  const isOpen = useSideNavStore(state => state.isOpen);
+  const toggle = useSideNavStore(state => state.toggle);
+  const setOpen = useSideNavStore(state => state.setOpen);
+
   const isMobile = useIsMobile();
   const pathname = usePathname();
+
   const navRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null); // 모바일 메뉴 닫힐 때 트리거 버튼으로 포커스 돌려주기 위함
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  // 모바일 메뉴 열릴 때
+  const isDrawerOpen = isMobile && isOpen;
+
+  const close = useCallback(() => setOpen(false), [setOpen]);
+
+  // 포커스가 드로어 밖(예: 트리거)에 있어도 닫히도록 document 레벨에서 처리
+  useEscKeyPress({ onEscPress: close, enabled: isDrawerOpen });
+
+  // 열릴 때 이전 포커스를 저장하고 패널로 이동, 닫힐 때 복원.
+  // isDrawerOpen 이 true 인 동안에만 동작하므로 마운트 시 포커스를 훔치지 않는다.
   useEffect(() => {
-    if (isOpen && isMobile) {
-      navRef.current?.focus();
-    }
-  }, [isOpen, isMobile]);
+    if (!isDrawerOpen) return;
 
-  // 모바일 메뉴 닫힐 때
-  useEffect(() => {
-    if (!isOpen && isMobile) {
-      triggerRef.current?.focus();
-    }
-  }, [isOpen, isMobile]);
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    navRef.current?.focus();
 
+    // 트리거는 모바일 트리에서 항상 렌더되므로 effect 시점에 캡처해 두어도 안전하다
+    const trigger = triggerRef.current;
+
+    return () => {
+      const restoreTarget = previousFocusRef.current ?? trigger;
+      restoreTarget?.focus?.();
+    };
+  }, [isDrawerOpen]);
+
+  // 안전망: 항목 클릭 외의 경로 변경(프로그래매틱 네비게이션, 뒤로가기 등)
   useEffect(() => {
     if (isMobile) setOpen(false);
   }, [pathname, isMobile, setOpen]);
+
   if (isMobile) {
     return (
-      <>
-        {/* 토글 버튼은 항상 고정 위치에 렌더 — 마운트/언마운트 없이 깜박임 제거 */}
-        <div className="fixed top-5 left-5 z-51">
-          <SideNavigationHeader isOpen={isOpen} onClick={toggle} />
-        </div>
-
+      // backdrop / drawer / trigger 를 하나의 z-40 스태킹 컨텍스트로 묶는다.
+      // 같은 z 안에서는 DOM 순서가 페인트 순서이므로 트리거가 드로어 위에 그려지면서도
+      // 그룹 전체는 z-50 오버레이 티어(Modal, LinkCardDetailPanel)보다 아래에 있게 된다.
+      <div className="pointer-events-none fixed inset-x-0 top-0 z-40 h-dvh">
         <AnimatePresence>
           {isOpen && (
             <motion.div
@@ -63,8 +70,9 @@ export default function SideNavigation() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="fixed inset-0 z-40 bg-black/30"
-              onClick={() => setOpen(false)}
+              transition={{ duration: 0.18 }}
+              onClick={close}
+              className="pointer-events-auto absolute inset-0 bg-black/10 backdrop-blur-[2px]"
             />
           )}
         </AnimatePresence>
@@ -76,30 +84,37 @@ export default function SideNavigation() {
               ref={navRef}
               role="dialog"
               aria-modal="true"
+              aria-label="사이드 내비게이션"
               tabIndex={-1}
-              onKeyDown={e => {
-                if (e.key === 'Escape') {
-                  setOpen(false);
-                }
-              }}
-              initial={{ x: -240 }}
+              initial={{ x: '-100%' }}
               animate={{ x: 0 }}
-              exit={{ x: -240 }}
+              exit={{ x: '-100%' }}
               transition={{ type: 'spring', stiffness: 200, damping: 24 }}
-              className="bg-gray50 fixed top-0 left-0 z-50 flex h-screen w-60 flex-col overflow-hidden p-5 shadow-md"
+              // 스크림이 더 이상 어둡지 않으므로 분리감은 elevation 으로 확보한다
+              className="bg-gray50 pointer-events-auto absolute top-0 left-0 flex h-full w-60 flex-col overflow-hidden p-5 shadow-[0_0_24px_rgba(17,19,29,0.16)] outline-none"
             >
-              <div className="flex h-full flex-col justify-between">
-                <div className="flex min-h-0 flex-1 flex-col">
-                  <div className="mb-10 h-10 shrink-0" />
-                  <MenuSection />
-                  <ChatRoomSection />
-                </div>
-                <SideNavigationBottom />
+              <div className={SCROLLER_CLASS}>
+                {/* 플로팅 트리거 자리 */}
+                <div className="mb-8 h-10 shrink-0" />
+                <MenuSection />
+                <ChatRoomSection />
               </div>
+              <SideNavigationBottom />
             </motion.div>
           )}
         </AnimatePresence>
-      </>
+
+        {/* 트리거는 DOM 상 마지막 = 같은 z 안에서 맨 위. 마운트/언마운트 없이 항상 렌더 */}
+        <div className="pointer-events-auto absolute top-5 left-5">
+          <SideNavigationHeader
+            ref={triggerRef}
+            isOpen={isOpen}
+            onClick={toggle}
+            variant="tertiary_neutral"
+            floating
+          />
+        </div>
+      </div>
     );
   }
 
@@ -107,16 +122,17 @@ export default function SideNavigation() {
     <motion.div
       animate={{ width: isOpen ? 240 : 80 }}
       transition={{ type: 'spring', stiffness: 200, damping: 24 }}
-      className="bg-gray50 sticky top-0 flex h-screen flex-col justify-between overflow-hidden p-5 shadow-md"
+      className="bg-gray50 sticky top-0 flex h-full shrink-0 flex-col overflow-hidden p-5 shadow-md"
     >
-      <div className="flex h-full flex-col justify-between">
-        <div className="flex min-h-0 flex-1 flex-col">
+      <div className={SCROLLER_CLASS}>
+        {/* 스크롤해도 헤더/메뉴는 상단에 고정 */}
+        <div className="bg-gray50 sticky top-0 z-1 shrink-0">
           <SideNavigationHeader isOpen={isOpen} onClick={toggle} />
           <MenuSection />
-          {isOpen && <ChatRoomSection />}
         </div>
-        <SideNavigationBottom />
+        {isOpen && <ChatRoomSection />}
       </div>
+      <SideNavigationBottom />
     </motion.div>
   );
 }

--- a/src/components/layout/SideNavigation/components/Bottom/SideNavigationBottom.tsx
+++ b/src/components/layout/SideNavigation/components/Bottom/SideNavigationBottom.tsx
@@ -3,6 +3,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/basics/Pop
 import Spinner from '@/components/basics/Spinner/Spinner';
 import { useLogout } from '@/hooks/useLogout';
 import { useUserInfo } from '@/hooks/useUserInfo';
+import { useCloseSideNavOnSelect } from '@/hooks/util/useCloseSideNavOnSelect';
 
 import NavItem from '../NavItem/NavItem';
 
@@ -27,6 +28,7 @@ const PROFILE_MENU_LINKS = [
 const SideNavigationBottom = () => {
   const { data: user, isLoading } = useUserInfo();
   const { mutate: handleLogout, isPending: isLoggingOut } = useLogout();
+  const closeSideNav = useCloseSideNavOnSelect();
   if (isLoading) {
     return (
       <div className="flex shrink-0 items-center justify-center p-2">
@@ -66,6 +68,7 @@ const SideNavigationBottom = () => {
                   onClick={() => {
                     window.open(href, '_blank', 'noopener,noreferrer');
                     close();
+                    closeSideNav();
                   }}
                 />
               ))}
@@ -77,6 +80,9 @@ const SideNavigationBottom = () => {
                 icon="IC_Logout"
                 radius="full"
                 className="w-full justify-start"
+                // 로그아웃은 드로어를 닫지 않는다. useLogout 의 성공/실패 콜백이
+                // 이 컴포넌트의 mutation observer 에 묶여 있어서, 여기서 언마운트하면
+                // '/' 로 보내는 리다이렉트가 실행되지 않는다. (성공 시 '/' 로 이동하면서 자연히 사라진다)
                 onClick={() => {
                   handleLogout();
                   close();

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/ChatItem.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/ChatItem.tsx
@@ -3,9 +3,11 @@
 import Button from '@/components/basics/Button/Button';
 import IconButton from '@/components/basics/IconButton/IconButton';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/basics/Popover';
+import { useCloseSideNavOnSelect } from '@/hooks/util/useCloseSideNavOnSelect';
 import { useModalStore } from '@/stores/modalStore';
 import type { EntityId } from '@/types/id';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 interface Props {
   id: EntityId;
@@ -13,67 +15,59 @@ interface Props {
 }
 
 const ChatItem = ({ id, label }: Props) => {
-  const router = useRouter();
   const open = useModalStore(state => state.open);
+  const closeSideNav = useCloseSideNavOnSelect();
+  const pathname = usePathname();
 
-  const handleItemClick = () => {
-    router.push(`/chat/${id}`);
-  };
-
-  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-  };
+  const href = `/chat/${id}`;
+  const isActive = pathname === href;
 
   return (
-    <>
-      <div
-        className="group bg-btn-tertiary-subtle-onpanel flex h-9 cursor-pointer items-center justify-between rounded-full pr-3 pl-3 transition-colors hover:pr-1"
-        onClick={handleItemClick}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleItemClick();
-          }
-        }}
-        role="button"
-        tabIndex={0}
+    // 더보기 버튼이 상시 노출되므로 pr 도 고정한다 (hover 마다 라벨이 밀리지 않도록)
+    <div className="group bg-btn-tertiary-subtle-onpanel flex h-9 shrink-0 items-center gap-1 rounded-full pr-1 pl-3 transition-colors">
+      <Link
+        href={href}
+        // 목록이 최대 수십 개라 뷰포트 진입 시 일괄 prefetch 가 터지는 것을 막는다
+        prefetch={false}
+        // 현재 열려 있는 채팅을 다시 눌러도 모바일 드로어가 닫히도록
+        onClick={closeSideNav}
+        aria-current={isActive ? 'page' : undefined}
+        // flex 로 만들면 text-overflow 가 먹지 않는다. 행 높이(h-9)와 같은 leading 으로 수직 정렬한다.
+        className="font-label-md text-gray500 group-hover:text-gray700 min-w-0 flex-1 truncate leading-9"
       >
-        <span className="font-label-md text-gray500 group-hover:text-gray700 min-w-0 truncate">
-          {label}
-        </span>
-        <Popover>
-          <PopoverTrigger popoverKey="chat_more">
-            <IconButton
+        {label}
+      </Link>
+      <Popover>
+        <PopoverTrigger popoverKey="chat_more">
+          <IconButton
+            variant="tertiary_subtle"
+            contextStyle="onPanel"
+            size="sm"
+            icon="IC_MoreVert"
+            ariaLabel={`${label} 채팅방 메뉴 더보기`}
+            className="shrink-0"
+          />
+        </PopoverTrigger>
+        <PopoverContent popoverKey="chat_more">
+          {close => (
+            <Button
+              label="채팅 삭제"
+              icon="IC_Delete"
               variant="tertiary_subtle"
               contextStyle="onPanel"
               size="sm"
-              icon="IC_MoreVert"
-              ariaLabel="채팅방 메뉴 더보기 버튼"
-              className="hidden shrink-0 group-hover:flex"
-              onClick={handleButtonClick}
+              radius="full"
+              className="m-3 pr-13"
+              onClick={() => {
+                close();
+                open('DELETE_CHAT', { chatId: id, title: label });
+                closeSideNav();
+              }}
             />
-          </PopoverTrigger>
-          <PopoverContent popoverKey="chat_more">
-            {close => (
-              <Button
-                label="채팅 삭제"
-                icon="IC_Delete"
-                variant="tertiary_subtle"
-                contextStyle="onPanel"
-                size="sm"
-                radius="full"
-                className="m-3 pr-13"
-                onClick={e => {
-                  e.stopPropagation();
-                  close();
-                  open('DELETE_CHAT', { chatId: id, title: label });
-                }}
-              />
-            )}
-          </PopoverContent>
-        </Popover>
-      </div>
-    </>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 };
 

--- a/src/components/layout/SideNavigation/components/ChatRoomSection/ChatRoomSection.tsx
+++ b/src/components/layout/SideNavigation/components/ChatRoomSection/ChatRoomSection.tsx
@@ -1,36 +1,33 @@
 import Label from '@/components/basics/Label/Label';
 import Spinner from '@/components/basics/Spinner/Spinner';
 import { useChatList } from '@/hooks/useChatList';
-import { useModalStore } from '@/stores/modalStore';
 
 import ChatItem from './ChatItem';
-import DeleteChatModal from './DeleteChatModal';
 
+/**
+ * 스크롤은 상위(SideNavigation)의 단일 스크롤러가 담당한다.
+ * 여기서 다시 overflow 를 잡으면 중첩 스크롤러가 되어 iOS 에서 터치가 갇힌다.
+ *
+ * DeleteChatModal 은 드로어 밖(SideNavModals)에서 렌더된다.
+ */
 const ChatRoomSection = () => {
   const { data: chats = [], isLoading, isError } = useChatList();
-  const { modal } = useModalStore();
 
   return (
-    <>
-      <div className="mt-10 flex min-h-0 flex-1 flex-col">
-        {(isLoading || chats.length !== 0) && <Label className="mb-2 shrink-0">채팅</Label>}
-        <div className="custom-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto">
-          {isLoading ? (
-            <Spinner />
-          ) : isError ? (
-            <p className="font-body-sm text-gray500 text-center whitespace-pre-line">
-              {'채팅방을 불러오지 못했어요\n잠시 후 다시 시도해주세요'}
-            </p>
-          ) : (
-            chats.map(chat => <ChatItem key={chat.id} id={chat.id} label={chat.title} />)
-          )}
-        </div>
+    <div className="mt-10 flex shrink-0 flex-col">
+      {(isLoading || chats.length !== 0) && <Label className="mb-2 shrink-0">채팅</Label>}
+      <div className="flex flex-col gap-2">
+        {isLoading ? (
+          <Spinner />
+        ) : isError ? (
+          <p className="font-body-sm text-gray500 text-center whitespace-pre-line">
+            {'채팅방을 불러오지 못했어요\n잠시 후 다시 시도해주세요'}
+          </p>
+        ) : (
+          chats.map(chat => <ChatItem key={chat.id} id={chat.id} label={chat.title} />)
+        )}
       </div>
-
-      {modal.type === 'DELETE_CHAT' && (
-        <DeleteChatModal chatId={modal.props.chatId} title={modal.props.title} />
-      )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/layout/SideNavigation/components/Header/SideNavigationHeader.tsx
+++ b/src/components/layout/SideNavigation/components/Header/SideNavigationHeader.tsx
@@ -1,23 +1,38 @@
 import IconButton from '@/components/basics/IconButton/IconButton';
-import { MouseEvent } from 'react';
+import clsx from 'clsx';
+import { MouseEvent, forwardRef } from 'react';
 
 interface Props {
   isOpen: boolean;
   onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  /** 기본은 패널 안에 놓이는 ghost 트리거. 페이지 콘텐츠 위에 뜨는 모바일 트리거는 배경이 있는 variant 를 쓴다. */
+  variant?: 'tertiary_subtle' | 'tertiary_neutral';
+  /** 페이지 콘텐츠 위에 떠 있는 모바일 플로팅 트리거 여부 */
+  floating?: boolean;
 }
 
-const SideNavigationHeader = ({ isOpen, onClick }: Props) => {
+const SideNavigationHeader = forwardRef<HTMLButtonElement, Props>(function SideNavigationHeader(
+  { isOpen, onClick, variant = 'tertiary_subtle', floating = false },
+  ref
+) {
   return (
-    <div className="mb-10">
+    <div className={clsx(!floating && 'mb-10')}>
       <IconButton
+        ref={ref}
         icon="IC_SidenavOpen"
-        variant="tertiary_subtle"
+        variant={variant}
         size="lg"
         ariaLabel={isOpen ? '좌측 사이드바 메뉴 닫기' : '좌측 사이드바 메뉴 열기'}
+        aria-expanded={isOpen}
         onClick={onClick}
+        className={clsx(
+          // 시각 크기 40px 은 유지하고 히트 영역만 48px 로 확장 (WCAG 2.5.5 / Apple 44pt)
+          'relative after:absolute after:-inset-1 after:content-[""]',
+          floating && 'shadow-sm'
+        )}
       />
     </div>
   );
-};
+});
 
 export default SideNavigationHeader;

--- a/src/components/layout/SideNavigation/components/MenuSection/MenuSection.tsx
+++ b/src/components/layout/SideNavigation/components/MenuSection/MenuSection.tsx
@@ -1,30 +1,40 @@
+import { useCloseSideNavOnSelect } from '@/hooks/util/useCloseSideNavOnSelect';
 import { useModalStore } from '@/stores/modalStore';
 
-import AddLinkModal from './AddLink';
 import AddLinkButton from './AddLink/AddLinkButton';
 import AllLinkButton from './AllLinkButton';
 import NewChatButton from './NewChatButton';
 
 const MenuSection = () => {
-  const { modal, open } = useModalStore();
+  const open = useModalStore(state => state.open);
+  const closeSideNav = useCloseSideNavOnSelect();
 
   const MENU_ITEMS = [
     { id: 'new-chat', item: <NewChatButton /> },
-    { id: 'add-link', item: <AddLinkButton onClick={() => open('ADD_LINK')} /> },
+    {
+      id: 'add-link',
+      item: (
+        <AddLinkButton
+          onClick={() => {
+            open('ADD_LINK');
+            closeSideNav();
+          }}
+        />
+      ),
+    },
     { id: 'all-link', item: <AllLinkButton /> },
   ];
 
+  // AddLinkModal 은 드로어 밖(SideNavModals)에서 렌더된다.
+  // 여기서 렌더하면 "선택 후 드로어 닫기"가 모달까지 언마운트시킨다.
   return (
-    <>
-      <nav className="flex flex-col gap-4">
-        {MENU_ITEMS.map(item => (
-          <div key={item.id} className="h-10">
-            {item.item}
-          </div>
-        ))}
-      </nav>
-      {modal.type === 'ADD_LINK' && <AddLinkModal />}
-    </>
+    <nav className="flex shrink-0 flex-col gap-4">
+      {MENU_ITEMS.map(item => (
+        <div key={item.id} className="h-10 shrink-0">
+          {item.item}
+        </div>
+      ))}
+    </nav>
   );
 };
 

--- a/src/components/layout/SideNavigation/components/NavItem/LinkNavItem.tsx
+++ b/src/components/layout/SideNavigation/components/NavItem/LinkNavItem.tsx
@@ -1,6 +1,7 @@
 import SVGIcon from '@/components/Icons/SVGIcon';
 import { IconMapTypes } from '@/components/Icons/icons';
 import { getSafeUrl } from '@/hooks/util/getSafeUrl';
+import { useCloseSideNavOnSelect } from '@/hooks/util/useCloseSideNavOnSelect';
 import { useSideNavStore } from '@/stores/sideNavStore';
 import { AnimatePresence, motion } from 'framer-motion';
 import Link from 'next/link';
@@ -14,6 +15,7 @@ interface LinkNavItemProps {
 
 const LinkNavItem = ({ label, href, icon, ariaLabel }: LinkNavItemProps) => {
   const { isOpen } = useSideNavStore();
+  const closeSideNav = useCloseSideNavOnSelect();
   const safeUrl = getSafeUrl(href);
   const isExternal = /^https?:\/\//i.test(safeUrl);
   const linkProps = isExternal ? { target: '_blank' as const, rel: 'noopener noreferrer' } : {};
@@ -21,6 +23,8 @@ const LinkNavItem = ({ label, href, icon, ariaLabel }: LinkNavItemProps) => {
   return (
     <Link
       href={safeUrl}
+      // 같은 경로를 다시 선택해도 모바일 드로어가 닫히도록 (pathname effect 로는 못 잡는 케이스)
+      onClick={closeSideNav}
       className="bg-btn-tertiary-subtle-onpanel group text-gray500 hover:text-gray700 flex h-10 w-full cursor-pointer items-center gap-2 overflow-hidden rounded-full px-2 transition-colors"
       aria-label={ariaLabel}
       {...linkProps}

--- a/src/components/layout/SideNavigation/components/SideNavModals.tsx
+++ b/src/components/layout/SideNavigation/components/SideNavModals.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useModalStore } from '@/stores/modalStore';
+
+import DeleteChatModal from './ChatRoomSection/DeleteChatModal';
+import AddLinkModal from './MenuSection/AddLink';
+
+/**
+ * SideNavigation 이 소유하지만 렌더 위치는 드로어 밖이어야 하는 모달들.
+ *
+ * 드로어 서브트리 안에 두면 "메뉴 선택 후 드로어 닫기"가 방금 연 모달까지
+ * 함께 언마운트시켜 모바일에서 모달이 깜빡이고 사라진다.
+ */
+export default function SideNavModals() {
+  const modal = useModalStore(state => state.modal);
+
+  return (
+    <>
+      {modal.type === 'ADD_LINK' && <AddLinkModal />}
+      {modal.type === 'DELETE_CHAT' && (
+        <DeleteChatModal chatId={modal.props.chatId} title={modal.props.title} />
+      )}
+    </>
+  );
+}

--- a/src/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.style.ts
+++ b/src/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel.style.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv({
   slots: {
-    root: 'bg-gray50 custom-scrollbar fixed inset-0 z-50 w-full overflow-x-hidden overflow-y-auto pt-2 pr-1 sm:inset-y-0 sm:right-0 sm:left-auto sm:w-[520px] xl:static xl:h-screen xl:w-[520px]',
+    root: 'bg-gray50 custom-scrollbar fixed inset-0 z-50 w-full overflow-x-hidden overflow-y-auto overscroll-contain pt-2 pr-1 sm:inset-y-0 sm:right-0 sm:left-auto sm:w-[520px] xl:static xl:h-full xl:w-[520px]',
     content: 'flex h-full flex-col gap-0 pb-6',
     header: 'flex items-center justify-between px-5 py-3',
     section: 'flex flex-col gap-2 px-5 pt-5 pb-4',

--- a/src/hooks/util/useCloseSideNavOnSelect.ts
+++ b/src/hooks/util/useCloseSideNavOnSelect.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useSideNavStore } from '@/stores/sideNavStore';
+import { useCallback } from 'react';
+
+import { useIsMobile } from './useIsMobile';
+
+/**
+ * 사이드 내비게이션에서 항목을 선택했을 때 호출한다.
+ *
+ * 모바일 드로어에서만 닫는다. 데스크톱에서 `isOpen` 은 "확장(240px)/축소(80px) 폭"을
+ * 의미하고 LinkNavItem / NavItem 의 라벨 표시에도 쓰이므로, 가드 없이 닫으면
+ * 클릭할 때마다 데스크톱 레일이 접힌다.
+ */
+export function useCloseSideNavOnSelect() {
+  const setOpen = useSideNavStore(state => state.setOpen);
+  const isMobile = useIsMobile();
+
+  return useCallback(() => {
+    if (isMobile) setOpen(false);
+  }, [isMobile, setOpen]);
+}
+
+export default useCloseSideNavOnSelect;

--- a/src/hooks/util/useIsMobile.ts
+++ b/src/hooks/util/useIsMobile.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+/** Tailwind `md` 브레이크포인트 미만을 모바일로 본다. */
+export const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
+
+/**
+ * matchMedia 를 useSyncExternalStore 로 구독한다.
+ *
+ * useEffect/useLayoutEffect 기반 구현과 달리
+ * - 서버 렌더링 시 useLayoutEffect 경고가 없고
+ * - 첫 클라이언트 렌더에서 곧바로 올바른 값을 반환한다 (한 커밋 늦지 않는다).
+ *
+ * 서버 스냅샷은 데스크톱(false) 기준이다.
+ */
+export function useIsMobile(query: string = MOBILE_MEDIA_QUERY) {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mediaQueryList = window.matchMedia(query);
+      mediaQueryList.addEventListener('change', onStoreChange);
+      return () => mediaQueryList.removeEventListener('change', onStoreChange);
+    },
+    [query]
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false
+  );
+}
+
+export default useIsMobile;

--- a/src/stories/SideNavigation.stories.tsx
+++ b/src/stories/SideNavigation.stories.tsx
@@ -1,14 +1,99 @@
 import SideNavigation from '@/components/layout/SideNavigation/SideNavigation';
-import type { Meta, StoryObj } from '@storybook/nextjs';
+import { mockChats } from '@/mocks/fixtures/chats';
+import { useSideNavStore } from '@/stores/sideNavStore';
+import type { User } from '@/types/user';
+import type { Decorator, Meta, StoryObj } from '@storybook/nextjs';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockUser: User = {
+  id: 'mock-user-1',
+  name: '방다연',
+  profileImageUrl: '',
+  email: 'user@example.com',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const buildSeededClient = (chatCount: number) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(['chats'], mockChats.slice(0, chatCount));
+  client.setQueryData(['userInfo'], mockUser);
+  return client;
+};
+
+/**
+ * SideNavigation 은 앱 셸(h-dvh + overflow-hidden) 안에서만 올바른 높이를 갖는다.
+ * 래퍼가 없으면 데스크톱의 `sticky h-full` 패널이 0 높이로 렌더된다.
+ */
+const withAppShell =
+  (chatCount: number): Decorator =>
+  Story => (
+    <QueryClientProvider client={buildSeededClient(chatCount)}>
+      <div className="flex h-dvh overflow-hidden bg-white">
+        <Story />
+        <main className="min-w-0 flex-1" />
+      </div>
+    </QueryClientProvider>
+  );
+
+const withSideNavOpen =
+  (isOpen: boolean): Decorator =>
+  Story => {
+    useSideNavStore.setState({ isOpen });
+    return <Story />;
+  };
 
 const meta: Meta<typeof SideNavigation> = {
   title: 'Components/Layout/SideNavigation',
   component: SideNavigation,
   tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
   argTypes: {},
 };
 export default meta;
 
 type Story = StoryObj<typeof SideNavigation>;
 
-export const Default: Story = {};
+export const DesktopExpanded: Story = {
+  decorators: [withSideNavOpen(true), withAppShell(6)],
+};
+
+export const DesktopCollapsed: Story = {
+  decorators: [withSideNavOpen(false), withAppShell(6)],
+};
+
+export const MobileDrawerClosed: Story = {
+  globals: { viewport: { value: 'mobile1' } },
+  decorators: [withSideNavOpen(false), withAppShell(6)],
+};
+
+export const MobileDrawerOpen: Story = {
+  globals: { viewport: { value: 'mobile1' } },
+  decorators: [withSideNavOpen(true), withAppShell(6)],
+};
+
+/**
+ * 짧은 뷰포트 + 긴 채팅 목록 = 내비 스크롤 회귀 가드.
+ * 메뉴/목록 전체가 스크롤로 도달 가능해야 하고, 하단 프로필 행은 항상 고정되어 있어야 한다.
+ */
+export const MobileShortViewport: Story = {
+  globals: {
+    viewport: {
+      value: 'shortMobile',
+      isRotated: false,
+    },
+  },
+  parameters: {
+    viewport: {
+      options: {
+        shortMobile: {
+          name: 'Short mobile (landscape-ish)',
+          styles: { width: '375px', height: '420px' },
+          type: 'mobile',
+        },
+      },
+    },
+  },
+  decorators: [withSideNavOpen(true), withAppShell(mockChats.length)],
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,8 +25,21 @@
 @layer base {
   body {
     @apply font-pretendard;
+    /* pull-to-refresh 및 내부 스크롤러 → 문서로의 scroll chaining 차단 */
+    overscroll-behavior-y: contain;
   }
 }
+
+/* ========== Z-INDEX SCALE ==========
+ *  0–20  페이지 내부 플로팅 (QueryBox, LinkCard 배지)
+ *  30    페이지 sticky 헤더
+ *  40    모바일 사이드내비 그룹 (backdrop + drawer + trigger, 단일 스태킹 컨텍스트)
+ *  50    오버레이 티어 (Modal, LinkCardDetailPanel, Popover, Tooltip)
+ *  60    Toast
+ *
+ * 40 그룹은 반드시 50 티어보다 아래여야 한다. 그렇지 않으면 전체화면 오버레이 위에
+ * 사이드내비 트리거가 떠서, 눌러도 드로어가 오버레이 뒤에 열려 "버튼이 안 먹는" 것처럼 보인다.
+ */
 
 /* ========== CUSTOM SCROLL BAR ========== */
 .custom-scrollbar::-webkit-scrollbar {


### PR DESCRIPTION
## 관련 이슈

- close #568

## PR 설명
- 사이드 내비 열렸을 때 background 스크롤 block
- 사이드내비 드로어 내부를 단일 스크롤러로 재구성
- 메뉴 선택 후 항상 닫히도록 수정
- 채팅 아이템 메뉴 버튼 상시 노출
- 사이드 내비 트리거 배경색 지정(`tertiary_neutral`)
- 진한 그림자 대신 약한 blur 처리

### 같이 고친 부수 버그

  - Popover/Trigger.tsx가 모든 팝오버 트리거의 접근성 이름을 지우고 있었음 — 'aria-label': undefined를 무조건 주입하는데, 호출부는 IconButton/Button의 자체
  prop인 ariaLabel을 넘기고, 두 컴포넌트가 {...rest}를 aria-label={ariaLabel} 뒤에 펼쳐서 덮어씀. 값이 있을 때만 주입하도록 수정 + 두 컴포넌트의 스프레드 순서
  정리
  - usePopoverPosition에 autoUpdate 없음 — 내비가 스크롤되면(#2) 열린 채팅 kebab 팝오버가 행에서 떨어짐. 추가하지 않았으면 #2가 새 버그를 만들 상황
  - AddLinkModal / DeleteChatModal이 드로어 서브트리 안에서 렌더 — #3을 켜면 방금 연 모달이 드로어와 함께 언마운트되어 깜빡이고 사라짐. SideNavModals로 셸 밖에
  호이스팅
  - triggerRef가 선언만 되고 어디에도 부착 안 됨 → 포커스 복원이 no-op. 게다가 닫힘 effect가 마운트 시에도 실행되어 모바일 진입마다 포커스를 훔칠 뻔한 구조.
  하나의 effect로 정리하고 <main>에 inert를 걸어 실제 focus trap 확보. Esc도 패널 onKeyDown(포커스가 안에 있을 때만 동작) → document 레벨 useEscKeyPress로 이동
  - useIsMobile이 useLayoutEffect 기반 → SSR 경고 + 한 커밋 늦은 값. useSyncExternalStore 기반 src/hooks/util/useIsMobile.ts로 분리
  - ChatItem이 role="button" div로 진짜 <button>을 감싼 중첩 인터랙티브 위반 → next/link로 교체. 미들클릭 / cmd+클릭 / AT 시맨틱 복원, 행별 고유
  ariaLabel(기존엔 전부 동일한 이름), aria-current, prefetch={false}(채팅 수십 개 일괄 prefetch 방지)
  - layout.tsx의 viewport가 문자열 export — App Router의 Viewport 객체 형태가 아니고, 생성 라우트 타입이 viewport?: any라 빌드에서도 안 잡히던 상태. 타입 객체로
  교체. maximum-scale=1은 복원 안 함 (확대 차단은 WCAG 1.4.4 위반)
  - Modal에 최대 높이 없음 → 짧은 모바일 화면에서 긴 본문이 잘림. max-h-[85dvh] overflow-y-auto overscroll-contain 추가
  - Storybook SideNavigation 스토리가 깨져 있었음 — preview.ts에 QueryClientProvider가 없어 ChatRoomSection/SideNavigationBottom이 "No QueryClient set"으로 죽던
  상태. 전역 데코레이터 추가 + 앱 셸 래퍼 + 데스크톱 확장/축소, 모바일 열림/닫힘, 짧은 뷰포트 5개 스토리로 확장