### PR TITLE
query_feedback 파라미터를 feedback_value로 변경

### DIFF
--- a/src/app/(route)/chat/[id]/ChatPage.tsx
+++ b/src/app/(route)/chat/[id]/ChatPage.tsx
@@ -10,7 +10,7 @@ import CopyButton from '@/components/wrappers/CopyButton';
 import LinkCardDetailPanel from '@/components/wrappers/LinkCardDetailPanel/LinkCardDetailPanel';
 import ReportModal from '@/components/wrappers/ReportModal/ReportModal';
 import { useChatStream } from '@/hooks/server/Chats/useChatStream';
-import { trackEvent } from '@/lib/client/analytics';
+import { trackEvent, trackQueryFeedback } from '@/lib/client/analytics';
 import { useModalStore } from '@/stores/modalStore';
 import { showToast } from '@/stores/toastStore';
 import type { ChatHistoryMessage } from '@/types/api/chatApi';
@@ -573,10 +573,7 @@ export default function Chat() {
 
         if (reaction === 'up') {
           if (message.queryId) {
-            trackEvent('query_feedback', {
-              query_id: message.queryId,
-              value: 'up',
-            });
+            trackQueryFeedback(message.queryId, 'up');
           }
 
           showToast({
@@ -588,10 +585,7 @@ export default function Chat() {
 
         if (reaction === 'down') {
           if (message.queryId) {
-            trackEvent('query_feedback', {
-              query_id: message.queryId,
-              value: 'down',
-            });
+            trackQueryFeedback(message.queryId, 'down');
           }
 
           showToast({

--- a/src/lib/client/analytics.test.ts
+++ b/src/lib/client/analytics.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { trackQueryFeedback } from './analytics';
+
+describe('trackQueryFeedback', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ['up', 'up'],
+    ['down', 'down'],
+  ] as const)('%s 피드백을 feedback_value로 전송한다', (_, feedbackValue) => {
+    const gtag = vi.fn();
+    vi.stubGlobal('window', { gtag });
+
+    trackQueryFeedback('query-123', feedbackValue);
+
+    expect(gtag).toHaveBeenCalledOnce();
+    expect(gtag).toHaveBeenCalledWith('event', 'query_feedback', {
+      query_id: 'query-123',
+      feedback_value: feedbackValue,
+    });
+    expect(gtag.mock.calls[0]?.[2]).not.toHaveProperty('value');
+  });
+});

--- a/src/lib/client/analytics.ts
+++ b/src/lib/client/analytics.ts
@@ -69,6 +69,13 @@ export const trackEvent = (name: string, params?: Record<string, unknown>) => {
   window.gtag('event', name, params ?? {});
 };
 
+export const trackQueryFeedback = (queryId: string, feedbackValue: 'up' | 'down') => {
+  trackEvent('query_feedback', {
+    query_id: queryId,
+    feedback_value: feedbackValue,
+  });
+};
+
 export const withAnalyticsContext = async <T extends object>(
   payload: T
 ): Promise<T & { clientId?: string; source: 'web' }> => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
   test: {
     workspace: [
       {
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.test.{ts,tsx}'],
+        },
+      },
+      {
         extends: true,
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config


### PR DESCRIPTION
## 관련 이슈

- close #567

## PR 설명

- `query_feedback` 이벤트의 GA4 기본 매개변수 `value` 충돌을 방지하기 위해 `feedback_value`로 변경했습니다.
- 좋아요와 싫어요 전송 경로가 공통 `trackQueryFeedback` 함수를 사용하도록 정리했습니다.
- `up`/`down` 값과 `query_id`가 유지되고 `value`가 포함되지 않는지 검증하는 단위 테스트를 추가했습니다.

## 검증

- Vitest unit 테스트 2건 통과
- TypeScript 타입 검사 통과
- ESLint 통과
- Prettier 검사 통과